### PR TITLE
Connection

### DIFF
--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -10,3 +10,7 @@ bytes = "0.5"
 quinn = "0.6"
 quinn-proto = "0.6"
 futures = "0.3"
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["rt-threaded", "macros"]}
+rcgen = "0.7.0"

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -316,10 +316,18 @@ where
     }
 }
 
-// TODO bound to stdError ?
+#[derive(Debug)]
 pub enum SendStreamError {
     Write(WriteError),
     NotReady,
+}
+
+impl std::error::Error for SendStreamError {}
+
+impl Display for SendStreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 impl From<WriteError> for SendStreamError {

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -1,0 +1,32 @@
+use bytes::Bytes;
+
+pub use crate::connection::Builder;
+use crate::{connection::ConnectionInner, quic, Error};
+
+pub struct Connection<C: quic::Connection<Bytes>> {
+    inner: ConnectionInner<C>,
+}
+
+impl<C> Connection<C>
+where
+    C: quic::Connection<Bytes>,
+{
+    pub async fn new(conn: C) -> Result<Self, Error> {
+        Ok(Self::builder().build(conn).await?)
+    }
+
+    pub fn builder() -> Builder<Connection<C>> {
+        Builder::new()
+    }
+}
+
+impl<C> Builder<Connection<C>>
+where
+    C: quic::Connection<Bytes>,
+{
+    pub async fn build(self, conn: C) -> Result<Connection<C>, Error> {
+        Ok(Connection {
+            inner: ConnectionInner::new(conn, self.max_field_section_size).await?,
+        })
+    }
+}

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -1,0 +1,48 @@
+use std::marker::PhantomData;
+
+use bytes::Bytes;
+use futures::future;
+
+use crate::{quic, Error};
+
+pub struct ConnectionInner<C: quic::Connection<Bytes>> {
+    quic: C,
+    max_field_section_size: u64,
+    control_send: C::SendStream,
+}
+
+impl<C> ConnectionInner<C>
+where
+    C: quic::Connection<Bytes>,
+{
+    pub async fn new(mut quic: C, max_field_section_size: u64) -> Result<Self, Error> {
+        let control_send = future::poll_fn(|mut cx| quic.poll_open_send_stream(&mut cx))
+            .await
+            .map_err(|e| Error::Io(e.into()))?;
+
+        Ok(Self {
+            quic,
+            control_send,
+            max_field_section_size,
+        })
+    }
+}
+
+pub struct Builder<T> {
+    pub(super) max_field_section_size: u64,
+    phtantom: PhantomData<T>,
+}
+
+impl<T> Builder<T> {
+    pub(super) fn new() -> Self {
+        Builder {
+            max_field_section_size: 0, // Unlimited
+            phtantom: PhantomData,
+        }
+    }
+
+    pub fn max_field_section_size(&mut self, value: u64) -> &mut Self {
+        self.max_field_section_size = value;
+        self
+    }
+}

--- a/h3/src/lib.rs
+++ b/h3/src/lib.rs
@@ -1,9 +1,20 @@
+#[allow(dead_code)]
+pub mod client;
 #[deny(missing_docs)]
 pub mod quic;
+#[allow(dead_code)]
+pub mod server;
 
 // TODO: remove once methods are effectively used through public API.
+#[allow(dead_code)]
+mod connection;
 #[allow(dead_code)]
 mod frame;
 mod proto;
 #[allow(dead_code)]
 mod qpack;
+
+#[derive(Debug)]
+pub enum Error {
+    Io(Box<dyn std::error::Error + Send + Sync>),
+}

--- a/h3/src/proto/headers.rs
+++ b/h3/src/proto/headers.rs
@@ -203,7 +203,7 @@ impl Field {
             return Ok(Field::Header((
                 HeaderName::from_bytes(name).map_err(|_| Error::invalid_name(name))?,
                 HeaderValue::from_bytes(value.as_ref())
-                    .or_else(|_| Err(Error::invalid_value(name, value)))?,
+                    .map_err(|_| Error::invalid_value(name, value))?,
             )));
         }
 
@@ -213,11 +213,11 @@ impl Field {
             b":path" => Field::Path(try_value(name, value)?),
             b":method" => Field::Method(
                 Method::from_bytes(value.as_ref())
-                    .or_else(|_| Err(Error::invalid_value(name, value)))?,
+                    .map_err(|_| Error::invalid_value(name, value))?,
             ),
             b":status" => Field::Status(
                 StatusCode::from_bytes(value.as_ref())
-                    .or_else(|_| Err(Error::invalid_value(name, value)))?,
+                    .map_err(|_| Error::invalid_value(name, value))?,
             ),
             _ => return Err(Error::invalid_name(name)),
         })

--- a/h3/src/quic.rs
+++ b/h3/src/quic.rs
@@ -21,7 +21,7 @@ pub trait Connection<B: Buf> {
     /// stream.
     type BidiStream: SendStream<B> + RecvStream;
     /// The error type that can be returned when accepting or opening a stream.
-    type Error;
+    type Error: Into<Box<dyn std::error::Error + Send + Sync>>;
 
     // Accepting streams
 
@@ -59,7 +59,7 @@ pub trait Connection<B: Buf> {
 /// A trait describing the "send" actions of a QUIC stream.
 pub trait SendStream<B: Buf> {
     /// The error type returned by fallible send methods.
-    type Error; // bounds?
+    type Error: Into<Box<dyn std::error::Error + Send + Sync>>;
 
     /// Polls if the stream can send more data.
     fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>>;

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -1,0 +1,32 @@
+use bytes::Bytes;
+
+pub use crate::connection::Builder;
+use crate::{connection::ConnectionInner, quic, Error};
+
+pub struct Connection<C: quic::Connection<Bytes>> {
+    inner: ConnectionInner<C>,
+}
+
+impl<C> Connection<C>
+where
+    C: quic::Connection<Bytes>,
+{
+    pub async fn new(conn: C) -> Result<Self, Error> {
+        Ok(Self::builder().build(conn).await?)
+    }
+
+    pub fn builder() -> Builder<Connection<C>> {
+        Builder::new()
+    }
+}
+
+impl<C> Builder<Connection<C>>
+where
+    C: quic::Connection<Bytes>,
+{
+    pub async fn build(&self, conn: C) -> Result<Connection<C>, Error> {
+        Ok(Connection {
+            inner: ConnectionInner::new(conn, self.max_field_section_size).await?,
+        })
+    }
+}


### PR DESCRIPTION
Adresses #19.

There is a deviation from the proposal here: no handshake, but only construct functions. Sorry for not figuring this out before, but the handshake part is actually out of H3 scope. It is a QUIC matter. Plus, there is no exhange needed prior the first request. Once QUIC+TLS negociated the ALPN, we're ready to work with H3.

I'm not sure where to provide a `const ALPN = b"h3"`. It is something that will always be needed since there is no H3 without QUIC, and no QUIC without TLS.