### PR TITLE
Request implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["h3", "h3-quinn"]
+members = ["h3", "h3-quinn", "tests/h3-tests"]

--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -10,7 +10,3 @@ bytes = "0.5"
 quinn = "0.6"
 quinn-proto = "0.6"
 futures = "0.3"
-
-[dev-dependencies]
-tokio = { version = "0.2", features = ["rt-threaded", "macros"]}
-rcgen = "0.7.0"

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
 use futures::{ready, FutureExt, StreamExt};
 
 use bytes::{Buf, Bytes};
-use h3::quic::{self, SendStream as _};
+use h3::quic;
 pub use quinn;
 use quinn::{
     generic::{IncomingBiStreams, IncomingUniStreams, NewConnection, OpenBi, OpenUni},
@@ -128,10 +128,6 @@ where
 
     fn split(self) -> (Self::SendStream, Self::RecvStream) {
         (self.send, self.recv)
-    }
-
-    fn id(&self) -> u64 {
-        self.send.id()
     }
 }
 

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -17,7 +17,7 @@ use quinn::{
 };
 use quinn_proto::crypto::Session;
 
-use h3::quic;
+use h3::quic::{self, SendStream as _};
 
 pub struct Connection<S: Session> {
     conn: quinn::generic::Connection<S>,
@@ -129,6 +129,10 @@ where
     fn split(self) -> (Self::SendStream, Self::RecvStream) {
         (self.send, self.recv)
     }
+
+    fn id(&self) -> u64 {
+        self.send.id()
+    }
 }
 
 impl<B, S> quic::RecvStream for BidiStream<B, S>
@@ -172,6 +176,10 @@ where
 
     fn send_data(&mut self, data: B) -> Result<(), Self::Error> {
         self.send.send_data(data)
+    }
+
+    fn id(&self) -> u64 {
+        self.send.id()
     }
 }
 
@@ -313,6 +321,10 @@ where
         }
         self.writing = Some(data);
         Ok(())
+    }
+
+    fn id(&self) -> u64 {
+        self.stream.id().0
     }
 }
 

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -11,13 +11,13 @@ use std::{
 use futures::{ready, FutureExt, StreamExt};
 
 use bytes::{Buf, Bytes};
+use h3::quic::{self, SendStream as _};
+pub use quinn;
 use quinn::{
     generic::{IncomingBiStreams, IncomingUniStreams, NewConnection, OpenBi, OpenUni},
     ConnectionError, VarInt, WriteError,
 };
 use quinn_proto::crypto::Session;
-
-use h3::quic::{self, SendStream as _};
 
 pub struct Connection<S: Session> {
     conn: quinn::generic::Connection<S>,
@@ -345,73 +345,5 @@ impl Display for SendStreamError {
 impl From<WriteError> for SendStreamError {
     fn from(e: WriteError) -> Self {
         Self::Write(e)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use h3::{client, server};
-    use quinn::{
-        Certificate, CertificateChain, ClientConfigBuilder, Endpoint, PrivateKey,
-        ServerConfigBuilder,
-    };
-    use rcgen;
-    use tokio;
-
-    #[tokio::test]
-    async fn connect() {
-        let (cert_chain, cert, key) = build_certs();
-        // Build client
-        let mut client_config = ClientConfigBuilder::default();
-        client_config.protocols(&[b"h3"]);
-        client_config.add_certificate_authority(cert).unwrap();
-
-        let mut client_endpoint_builder = Endpoint::builder();
-        client_endpoint_builder.default_client_config(client_config.build());
-        let (client_endpoint, _) = client_endpoint_builder
-            .bind(&"[::]:0".parse().unwrap())
-            .unwrap();
-
-        let client = async {
-            let conn = client_endpoint
-                .connect(&"[::1]:4433".parse().unwrap(), "localhost")
-                .unwrap()
-                .await
-                .unwrap();
-            client::Connection::new(Connection::new(conn))
-                .await
-                .unwrap();
-        };
-
-        // Build server
-        let mut server_config = ServerConfigBuilder::default();
-        server_config.protocols(&[b"h3"]);
-        server_config.certificate(cert_chain, key).unwrap();
-
-        let mut server_endpoint_builder = Endpoint::builder();
-        server_endpoint_builder.listen(server_config.build());
-
-        let (_, mut incoming) = server_endpoint_builder
-            .bind(&"[::]:4433".parse().unwrap())
-            .unwrap();
-
-        let server = async {
-            let conn = incoming.next().await.unwrap().await.unwrap();
-            server::Connection::builder()
-                .max_field_section_size(10 * 1024)
-                .build(Connection::new(conn))
-                .await
-                .unwrap();
-        };
-
-        tokio::join!(server, client);
-    }
-
-    pub fn build_certs() -> (CertificateChain, Certificate, PrivateKey) {
-        let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
-        let key = PrivateKey::from_der(&cert.serialize_private_key_der()).unwrap();
-        let cert = Certificate::from_der(&cert.serialize_der().unwrap()).unwrap();
-        (CertificateChain::from_certs(vec![cert.clone()]), cert, key)
     }
 }

--- a/h3/Cargo.toml
+++ b/h3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "h3"
 version = "0.0.0"
-authors = ["Sean McArthur <sean@seanmonstar.com>"]
+authors = ["Sean McArthur <sean@seanmonstar.com>", "Jean-Christophe BEGUE <jc.begue@pm.me>"]
 edition = "2018"
 
 [dependencies]

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -1,7 +1,16 @@
-use bytes::Bytes;
+use std::convert::TryFrom;
+use std::marker::PhantomData;
 
-pub use crate::connection::Builder;
-use crate::{connection::ConnectionInner, quic, Error};
+use bytes::{Bytes, BytesMut};
+use futures::future;
+use http::{request, HeaderMap, Response};
+
+use crate::{
+    connection::{Builder, ConnectionInner},
+    frame::{self, FrameStream},
+    proto::{frame::Frame, headers::Header},
+    qpack, quic, Error,
+};
 
 pub struct Connection<C: quic::Connection<Bytes>> {
     inner: ConnectionInner<C>,
@@ -18,6 +27,34 @@ where
     pub fn builder() -> Builder<Connection<C>> {
         Builder::new()
     }
+
+    pub async fn send_request(
+        &mut self,
+        req: http::Request<()>,
+    ) -> Result<RequestStream<FrameStream<C::BidiStream>, Bytes>, Error> {
+        let (parts, _) = req.into_parts();
+        let request::Parts {
+            method,
+            uri,
+            headers,
+            ..
+        } = parts;
+        let headers = Header::request(method, uri, headers)?;
+
+        let mut stream = future::poll_fn(|mut cx| self.inner.quic.poll_open_bidi_stream(&mut cx))
+            .await
+            .map_err(|e| Error::Io(e.into()))?;
+
+        let mut block = BytesMut::new();
+        qpack::encode_stateless(&mut block, headers)?;
+
+        frame::write(&mut stream, Frame::Headers(block.freeze())).await?;
+
+        Ok(RequestStream {
+            stream: FrameStream::new(stream),
+            _phantom: PhantomData,
+        })
+    }
 }
 
 impl<C> Builder<Connection<C>>
@@ -28,5 +65,65 @@ where
         Ok(Connection {
             inner: ConnectionInner::new(conn, self.max_field_section_size).await?,
         })
+    }
+}
+
+pub struct RequestStream<S, B> {
+    stream: S,
+    _phantom: PhantomData<B>,
+}
+
+impl<S> RequestStream<FrameStream<S>, Bytes>
+where
+    S: quic::RecvStream,
+{
+    /// Receive response headers
+    pub async fn recv_response(&mut self) -> Result<Response<()>, Error> {
+        let mut frame = future::poll_fn(|cx| self.stream.poll_next(cx))
+            .await?
+            .ok_or(Error::Peer("Did not receive response headers"))?;
+
+        let fields = if let Frame::Headers(ref mut encoded) = frame {
+            qpack::decode_stateless(encoded)?
+        } else {
+            return Err(Error::Peer("First response frame is not headers"));
+        };
+
+        let (status, mut fields) = Header::try_from(fields)?.into_response_parts()?;
+        let mut resp = Response::builder().status(status);
+        resp.headers_mut().replace(&mut fields);
+
+        Ok(resp.body(()).map_err(|_| Error::Peer("invalid headers"))?)
+    }
+
+    /// Receive some of the request body.
+    pub async fn recv_data(&mut self) -> Result<Option<Bytes>, Error> {
+        Ok(future::poll_fn(|cx| self.stream.poll_data(cx)).await?)
+    }
+}
+
+impl<S> RequestStream<S, Bytes>
+where
+    S: quic::SendStream<Bytes>,
+{
+    /// Send some data on the response body.
+    pub async fn send_data(&mut self, buf: Bytes) -> Result<(), Error> {
+        self.stream.send_data(buf).map_err(|e| Error::Io(e.into()))
+    }
+
+    /// Send a set of trailers to end the response.
+    pub async fn send_trailers(&mut self, trailers: HeaderMap) -> Result<(), Error> {
+        let mut block = BytesMut::new();
+        qpack::encode_stateless(&mut block, Header::trailer(trailers))?;
+
+        frame::write(&mut self.stream, Frame::Headers(block.freeze())).await?;
+
+        Ok(())
+    }
+
+    pub async fn finish(&mut self) -> Result<(), Error> {
+        future::poll_fn(|cx| self.stream.poll_finish(cx))
+            .await
+            .map_err(|e| Error::Io(e.into()))
     }
 }

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -1,9 +1,15 @@
-use std::marker::PhantomData;
+use std::{convert::TryFrom, marker::PhantomData};
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use futures::future;
+use http::HeaderMap;
 
-use crate::{quic, Error};
+use crate::{
+    frame::{self, FrameStream},
+    proto::frame::Frame,
+    proto::headers::Header,
+    qpack, quic, Error,
+};
 
 pub struct ConnectionInner<C: quic::Connection<Bytes>> {
     pub(super) quic: C,
@@ -44,5 +50,103 @@ impl<T> Builder<T> {
     pub fn max_field_section_size(&mut self, value: u64) -> &mut Self {
         self.max_field_section_size = value;
         self
+    }
+}
+
+pub struct RequestStream<S, B, T> {
+    pub(super) stream: S,
+    pub(super) trailers: Option<Bytes>,
+    _phantom_buffer: PhantomData<B>,
+    _phantom_side: PhantomData<T>,
+}
+
+impl<S, B, T> RequestStream<S, B, T> {
+    pub fn new(stream: S) -> Self {
+        Self {
+            stream,
+            trailers: None,
+            _phantom_buffer: PhantomData,
+            _phantom_side: PhantomData,
+        }
+    }
+}
+
+impl<S, T> RequestStream<FrameStream<S>, Bytes, T>
+where
+    S: quic::RecvStream,
+{
+    /// Receive some of the request body.
+    pub async fn recv_data(&mut self) -> Result<Option<Bytes>, Error> {
+        match future::poll_fn(|cx| self.stream.poll_next(cx)).await? {
+            Some(Frame::Data { .. }) => (),
+            Some(Frame::Headers(encoded)) => {
+                self.trailers = Some(encoded);
+                return Ok(None);
+            }
+            Some(_) => return Err(Error::Peer("Unexpected frame type on request stream")),
+            None => return Ok(None),
+        }
+
+        Ok(future::poll_fn(|cx| self.stream.poll_data(cx)).await?)
+    }
+
+    /// Receive trailers
+    pub async fn recv_trailers(&mut self) -> Result<Option<HeaderMap>, Error> {
+        let mut trailers = if let Some(encoded) = self.trailers.take() {
+            encoded
+        } else {
+            match future::poll_fn(|cx| self.stream.poll_next(cx)).await? {
+                Some(Frame::Headers(encoded)) => encoded,
+                Some(_) => return Err(Error::Peer("Unexpected frame type on request stream")),
+                None => return Ok(None),
+            }
+        };
+
+        Ok(Some(
+            Header::try_from(qpack::decode_stateless(&mut trailers)?)?.into_fields(),
+        ))
+    }
+}
+
+impl<S, T> RequestStream<S, Bytes, T>
+where
+    S: quic::SendStream<Bytes>,
+{
+    /// Send some data on the response body.
+    pub async fn send_data(&mut self, buf: Bytes) -> Result<(), Error> {
+        frame::write(
+            &mut self.stream,
+            Frame::Data {
+                len: buf.len() as u64,
+            },
+        )
+        .await?;
+        self.stream
+            .send_data(buf)
+            .map_err(|e| Error::Io(e.into()))?;
+        future::poll_fn(|cx| self.stream.poll_ready(cx))
+            .await
+            .map_err(|e| Error::Io(e.into()))?;
+
+        Ok(())
+    }
+
+    /// Send a set of trailers to end the request.
+    pub async fn send_trailers(&mut self, trailers: HeaderMap) -> Result<(), Error> {
+        let mut block = BytesMut::new();
+        qpack::encode_stateless(&mut block, Header::trailer(trailers))?;
+
+        frame::write(&mut self.stream, Frame::Headers(block.freeze())).await?;
+
+        Ok(())
+    }
+
+    pub async fn finish(&mut self) -> Result<(), Error> {
+        future::poll_fn(|cx| self.stream.poll_ready(cx))
+            .await
+            .map_err(|e| Error::Io(e.into()))?;
+        future::poll_fn(|cx| self.stream.poll_finish(cx))
+            .await
+            .map_err(|e| Error::Io(e.into()))
     }
 }

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -6,7 +6,7 @@ use futures::future;
 use crate::{quic, Error};
 
 pub struct ConnectionInner<C: quic::Connection<Bytes>> {
-    quic: C,
+    pub(super) quic: C,
     max_field_section_size: u64,
     control_send: C::SendStream,
 }

--- a/h3/src/frame/buf.rs
+++ b/h3/src/frame/buf.rs
@@ -20,11 +20,6 @@ impl<T: Buf> BufList<T> {
         self.bufs.push_back(buf);
     }
 
-    #[inline]
-    pub(crate) fn bufs_cnt(&self) -> usize {
-        self.bufs.len()
-    }
-
     pub fn cursor(&self) -> Cursor<T> {
         Cursor {
             buf: &self,

--- a/h3/src/frame/mod.rs
+++ b/h3/src/frame/mod.rs
@@ -192,10 +192,8 @@ impl From<frame::Error> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::frame;
 
     use std::collections::VecDeque;
-
     use assert_matches::assert_matches;
     use bytes::BufMut;
     use futures::future::poll_fn;
@@ -205,9 +203,7 @@ mod tests {
 
     #[test]
     fn one_frame() {
-        let frame = frame::Headers {
-            encoded: b"salut"[..].into(),
-        };
+        let frame = Frame::Headers(b"salut"[..].into());
 
         let mut buf = BytesMut::with_capacity(16);
         frame.encode(&mut buf);
@@ -219,9 +215,7 @@ mod tests {
 
     #[test]
     fn incomplete_frame() {
-        let frame = frame::Headers {
-            encoded: b"salut"[..].into(),
-        };
+        let frame = Frame::Headers(b"salut"[..].into());
 
         let mut buf = BytesMut::with_capacity(16);
         frame.encode(&mut buf);
@@ -234,9 +228,7 @@ mod tests {
 
     #[test]
     fn header_spread_multiple_buf() {
-        let frame = frame::Headers {
-            encoded: b"salut"[..].into(),
-        };
+        let frame = Frame::Headers(b"salut"[..].into());
 
         let mut buf = BytesMut::with_capacity(16);
         frame.encode(&mut buf);
@@ -252,9 +244,7 @@ mod tests {
     #[test]
     fn varint_spread_multiple_buf() {
         let payload = "salut".repeat(1024);
-        let frame = frame::Headers {
-            encoded: payload.into(),
-        };
+        let frame = Frame::Headers(payload.into());
 
         let mut buf = BytesMut::with_capacity(16);
         frame.encode(&mut buf);
@@ -270,16 +260,10 @@ mod tests {
     #[test]
     fn two_frames_then_incomplete() {
         let mut buf = BytesMut::with_capacity(64);
-        Frame::Headers(frame::Headers {
-            encoded: b"header"[..].into(),
-        })
-        .encode(&mut buf);
+        Frame::Headers(b"header"[..].into()).encode(&mut buf);
         Frame::Data { len: 4 }.encode(&mut buf);
         buf.put_slice(&b"body"[..]);
-        Frame::Headers(frame::Headers {
-            encoded: b"trailer"[..].into(),
-        })
-        .encode(&mut buf);
+        Frame::Headers(b"trailer"[..].into()).encode(&mut buf);
 
         buf.truncate(buf.len() - 1);
         let mut buf = BufList::from(buf);
@@ -312,16 +296,10 @@ mod tests {
         let mut recv = FakeRecv::default();
         let mut buf = BytesMut::with_capacity(64);
 
-        Frame::Headers(frame::Headers {
-            encoded: b"header"[..].into(),
-        })
-        .encode(&mut buf);
+        Frame::Headers(b"header"[..].into()).encode(&mut buf);
         Frame::Data { len: 4 }.encode(&mut buf);
         buf.put_slice(&b"body"[..]);
-        Frame::Headers(frame::Headers {
-            encoded: b"trailer"[..].into(),
-        })
-        .encode(&mut buf);
+        Frame::Headers(b"trailer"[..].into()).encode(&mut buf);
         recv.chunk(buf.freeze());
         let mut stream = FrameStream::new(recv);
 
@@ -348,10 +326,7 @@ mod tests {
         let mut recv = FakeRecv::default();
         let mut buf = BytesMut::with_capacity(64);
 
-        Frame::Headers(frame::Headers {
-            encoded: b"header"[..].into(),
-        })
-        .encode(&mut buf);
+        Frame::Headers(b"header"[..].into()).encode(&mut buf);
         let mut buf = buf.freeze();
         recv.chunk(buf.split_to(buf.len() - 1));
         let mut stream = FrameStream::new(recv);

--- a/h3/src/frame/mod.rs
+++ b/h3/src/frame/mod.rs
@@ -161,7 +161,7 @@ where
     }
 
     fn id(&self) -> u64 {
-        BidiStream::id(&self.stream)
+        self.stream.id()
     }
 }
 

--- a/h3/src/frame/mod.rs
+++ b/h3/src/frame/mod.rs
@@ -241,10 +241,10 @@ impl From<frame::Error> for Error {
 mod tests {
     use super::*;
 
-    use std::collections::VecDeque;
     use assert_matches::assert_matches;
     use bytes::BufMut;
     use futures::future::poll_fn;
+    use std::collections::VecDeque;
     use tokio;
 
     // Decoder

--- a/h3/src/lib.rs
+++ b/h3/src/lib.rs
@@ -18,10 +18,35 @@ mod qpack;
 pub enum Error {
     Io(Box<dyn std::error::Error + Send + Sync>),
     Qpack(qpack::Error),
+    Peer(&'static str),
+    Frame(proto::frame::Error),
+    Header(proto::headers::Error),
 }
 
 impl From<qpack::EncoderError> for Error {
     fn from(e: qpack::EncoderError) -> Self {
         Error::Qpack(qpack::Error::Encoder(e))
+    }
+}
+
+impl From<qpack::DecoderError> for Error {
+    fn from(e: qpack::DecoderError) -> Self {
+        Error::Qpack(qpack::Error::Decoder(e))
+    }
+}
+
+impl From<proto::headers::Error> for Error {
+    fn from(e: proto::headers::Error) -> Self {
+        Error::Header(e)
+    }
+}
+
+impl From<frame::Error> for Error {
+    fn from(e: frame::Error) -> Self {
+        match e {
+            frame::Error::Quic(e) => Error::Io(e),
+            frame::Error::Proto(e) => Error::Frame(e),
+            frame::Error::UnexpectedEnd => Error::Peer("Received incomplete frame"),
+        }
     }
 }

--- a/h3/src/lib.rs
+++ b/h3/src/lib.rs
@@ -17,4 +17,11 @@ mod qpack;
 #[derive(Debug)]
 pub enum Error {
     Io(Box<dyn std::error::Error + Send + Sync>),
+    Qpack(qpack::Error),
+}
+
+impl From<qpack::EncoderError> for Error {
+    fn from(e: qpack::EncoderError) -> Self {
+        Error::Qpack(qpack::Error::Encoder(e))
+    }
 }

--- a/h3/src/lib.rs
+++ b/h3/src/lib.rs
@@ -1,14 +1,10 @@
-#[allow(dead_code)]
 pub mod client;
 #[deny(missing_docs)]
 pub mod quic;
-#[allow(dead_code)]
 pub mod server;
 
-// TODO: remove once methods are effectively used through public API.
 #[allow(dead_code)]
 mod connection;
-#[allow(dead_code)]
 mod frame;
 mod proto;
 #[allow(dead_code)]

--- a/h3/src/proto/headers.rs
+++ b/h3/src/proto/headers.rs
@@ -21,10 +21,14 @@ pub struct Header {
 
 #[allow(clippy::len_without_is_empty)]
 impl Header {
-    pub fn request(method: Method, uri: Uri, fields: HeaderMap) -> Self {
-        Self {
-            pseudo: Pseudo::request(method, uri),
-            fields,
+    pub fn request(method: Method, uri: Uri, fields: HeaderMap) -> Result<Self, Error> {
+        match (uri.authority(), fields.get("host")) {
+            (None, None) => Err(Error::MissingAuthority),
+            (Some(a), Some(h)) if a.as_str() != h => Err(Error::ContradictedAuthority),
+            _ => Ok(Self {
+                pseudo: Pseudo::request(method, uri),
+                fields,
+            }),
         }
     }
 

--- a/h3/src/qpack/mod.rs
+++ b/h3/src/qpack/mod.rs
@@ -1,7 +1,7 @@
 pub use self::{
     decoder::{ack_header, stream_canceled, Decoder, Error as DecoderError},
     dynamic::Error as DynamicTableError,
-    encoder::Encoder,
+    encoder::{Encoder, Error as EncoderError},
     field::HeaderField,
 };
 
@@ -21,3 +21,9 @@ mod prefix_string;
 
 #[cfg(test)]
 mod tests;
+
+#[derive(Debug)]
+pub enum Error {
+    Encoder(EncoderError),
+    Decoder(DecoderError),
+}

--- a/h3/src/qpack/mod.rs
+++ b/h3/src/qpack/mod.rs
@@ -1,7 +1,7 @@
 pub use self::{
-    decoder::{ack_header, stream_canceled, Decoder, Error as DecoderError},
+    decoder::{ack_header, decode_stateless, stream_canceled, Decoder, Error as DecoderError},
     dynamic::Error as DynamicTableError,
-    encoder::{Encoder, Error as EncoderError},
+    encoder::{encode_stateless, Encoder, Error as EncoderError},
     field::HeaderField,
 };
 

--- a/h3/src/quic.rs
+++ b/h3/src/quic.rs
@@ -19,7 +19,7 @@ pub trait Connection<B: Buf> {
     type RecvStream: RecvStream;
     /// The stream type returned when accepting or opening a bidirectional
     /// stream.
-    type BidiStream: SendStream<B> + RecvStream;
+    type BidiStream: BidiStream<B> + SendStream<B> + RecvStream;
     /// The error type that can be returned when accepting or opening a stream.
     type Error: Into<Box<dyn std::error::Error + Send + Sync>>;
 

--- a/h3/src/quic.rs
+++ b/h3/src/quic.rs
@@ -106,7 +106,4 @@ pub trait BidiStream<B: Buf>: SendStream<B> + RecvStream {
 
     /// Split this stream into two halves.
     fn split(self) -> (Self::SendStream, Self::RecvStream);
-
-    /// Get QUIC send stream id
-    fn id(&self) -> u64;
 }

--- a/h3/src/quic.rs
+++ b/h3/src/quic.rs
@@ -72,6 +72,9 @@ pub trait SendStream<B: Buf> {
 
     /// Send a QUIC reset code.
     fn reset(&mut self, reset_code: u64);
+
+    /// Get QUIC send stream id
+    fn id(&self) -> u64;
 }
 
 /// A trait describing the "receive" actions of a QUIC stream.
@@ -103,4 +106,7 @@ pub trait BidiStream<B: Buf>: SendStream<B> + RecvStream {
 
     /// Split this stream into two halves.
     fn split(self) -> (Self::SendStream, Self::RecvStream);
+
+    /// Get QUIC send stream id
+    fn id(&self) -> u64;
 }

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -1,7 +1,17 @@
-use bytes::Bytes;
+use std::convert::TryFrom;
+use std::marker::PhantomData;
 
-pub use crate::connection::Builder;
-use crate::{connection::ConnectionInner, quic, Error};
+use bytes::{Bytes, BytesMut};
+use futures::future;
+use http::{response, HeaderMap, Request, Response};
+
+use crate::frame;
+use crate::{
+    connection::{Builder, ConnectionInner},
+    frame::FrameStream,
+    proto::{frame::Frame, headers::Header},
+    qpack, quic, Error,
+};
 
 pub struct Connection<C: quic::Connection<Bytes>> {
     inner: ConnectionInner<C>,
@@ -18,6 +28,49 @@ where
     pub fn builder() -> Builder<Connection<C>> {
         Builder::new()
     }
+
+    pub async fn accept(
+        &mut self,
+    ) -> Result<
+        Option<(
+            Request<()>,
+            RequestStream<FrameStream<C::BidiStream>, Bytes>,
+        )>,
+        Error,
+    > {
+        let stream = future::poll_fn(|cx| self.inner.quic.poll_accept_bidi_stream(cx))
+            .await
+            .map_err(|e| Error::Io(e.into()))?;
+
+        let mut stream = match stream {
+            None => return Ok(None),
+            Some(s) => FrameStream::new(s),
+        };
+
+        let frame = future::poll_fn(|cx| stream.poll_next(cx)).await?;
+
+        let mut encoded = match frame {
+            Some(Frame::Headers(h)) => h,
+            None => return Err(Error::Peer("request stream closed before headers")),
+            Some(_) => return Err(Error::Peer("first request frame is not headers")),
+        };
+
+        let fields = qpack::decode_stateless(&mut encoded)?;
+        let (method, uri, mut headers) = Header::try_from(fields)?.into_request_parts()?;
+
+        let mut request_builder = http::Request::builder().method(method).uri(uri);
+        request_builder.headers_mut().replace(&mut headers);
+
+        Ok(Some((
+            request_builder
+                .body(())
+                .map_err(|_| Error::Peer("invalid headers"))?,
+            RequestStream {
+                stream,
+                _phantom: PhantomData,
+            },
+        )))
+    }
 }
 
 impl<C> Builder<Connection<C>>
@@ -28,5 +81,76 @@ where
         Ok(Connection {
             inner: ConnectionInner::new(conn, self.max_field_section_size).await?,
         })
+    }
+}
+
+pub struct RequestStream<S, B> {
+    stream: S,
+    _phantom: PhantomData<B>,
+}
+
+impl<S> RequestStream<S, Bytes>
+where
+    S: quic::SendStream<Bytes>,
+{
+    /// Send response headers
+    pub async fn send_response(&mut self, resp: Response<()>) -> Result<(), Error> {
+        let (parts, _) = resp.into_parts();
+        let response::Parts {
+            status, headers, ..
+        } = parts;
+        let headers = Header::response(status, headers);
+
+        let mut block = BytesMut::new();
+        qpack::encode_stateless(&mut block, headers)?;
+
+        frame::write(&mut self.stream, Frame::Headers(block.freeze())).await?;
+
+        Ok(())
+    }
+
+    /// Send some data on the response body.
+    pub async fn send_data(&mut self, buf: Bytes) -> Result<(), Error> {
+        self.stream.send_data(buf).map_err(|e| Error::Io(e.into()))
+    }
+
+    /// Send a set of trailers to end the response.
+    pub async fn send_trailers(&mut self, trailers: HeaderMap) -> Result<(), Error> {
+        let mut block = BytesMut::new();
+        qpack::encode_stateless(&mut block, Header::trailer(trailers))?;
+
+        frame::write(&mut self.stream, Frame::Headers(block.freeze())).await?;
+
+        Ok(())
+    }
+
+    // Wait for all data to be sent and close the stream
+    pub async fn finish(&mut self) -> Result<(), Error> {
+        future::poll_fn(|cx| self.stream.poll_finish(cx))
+            .await
+            .map_err(|e| Error::Io(e.into()))
+    }
+}
+
+impl<S> RequestStream<FrameStream<S>, Bytes>
+where
+    S: quic::RecvStream,
+{
+    /// Receive some of the request body.
+    pub async fn recv_data(&mut self) -> Result<Option<Bytes>, Error> {
+        Ok(future::poll_fn(|cx| self.stream.poll_data(cx)).await?)
+    }
+
+    /// Receive an optional set of trailers for the request.
+    pub async fn recv_trailers(&mut self) -> Result<Option<HeaderMap>, Error> {
+        let mut frame = future::poll_fn(|cx| self.stream.poll_next(cx)).await?;
+
+        let fields = match frame {
+            Some(Frame::Headers(ref mut b)) => qpack::decode_stateless(b)?,
+            Some(_) => return Err(Error::Peer("Unexpected frame types")),
+            None => return Ok(None),
+        };
+
+        Ok(Some(Header::try_from(fields)?.into_fields()))
     }
 }

--- a/tests/h3-tests/Cargo.toml
+++ b/tests/h3-tests/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "h3-tests"
+version = "0.0.1"
+authors = [ "Jean-Christophe BEGUE <jc.begue@pm.me>" ]
+publish = false
+edition = "2018"
+
+[dependencies]
+h3 = { path = "../../h3" }
+h3-quinn = { path = "../../h3-quinn" }
+rcgen = { version = "0.7.0" }
+bytes = "0.5.6"
+futures = "0.3"
+http = "0.2.1"
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["rt-threaded", "macros"]}

--- a/tests/h3-tests/src/lib.rs
+++ b/tests/h3-tests/src/lib.rs
@@ -1,0 +1,96 @@
+use std::net::{Ipv6Addr, ToSocketAddrs};
+
+use bytes::Bytes;
+use futures::StreamExt;
+use h3::quic;
+use h3_quinn::{
+    quinn::{
+        Certificate, CertificateChain, ClientConfigBuilder, Endpoint, Incoming, PrivateKey,
+        ServerConfigBuilder,
+    },
+    Connection,
+};
+
+#[derive(Clone)]
+pub struct Pair {
+    port: u16,
+    cert_chain: CertificateChain,
+    cert: Certificate,
+    key: PrivateKey,
+}
+
+impl Pair {
+    pub fn new() -> Self {
+        let (cert_chain, cert, key) = build_certs();
+        Self {
+            port: 0,
+            cert_chain,
+            cert,
+            key,
+        }
+    }
+
+    pub fn server(&mut self) -> Server {
+        let mut server_config = ServerConfigBuilder::default();
+        server_config.protocols(&[b"h3"]);
+        server_config
+            .certificate(self.cert_chain.clone(), self.key.clone())
+            .unwrap();
+
+        let mut server_endpoint_builder = Endpoint::builder();
+        server_endpoint_builder.listen(server_config.build());
+
+        let (endpoint, incoming) = server_endpoint_builder
+            .bind(&"[::]:0".parse().unwrap())
+            .unwrap();
+
+        self.port = endpoint.local_addr().unwrap().port();
+
+        Server { incoming }
+    }
+
+    pub async fn client(&self) -> impl quic::Connection<Bytes> {
+        let addr = (Ipv6Addr::LOCALHOST, self.port)
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap();
+
+        let mut client_config = ClientConfigBuilder::default();
+        client_config.protocols(&[b"h3"]);
+        client_config
+            .add_certificate_authority(self.cert.clone())
+            .unwrap();
+
+        let mut client_endpoint_builder = Endpoint::builder();
+        client_endpoint_builder.default_client_config(client_config.build());
+        let (client_endpoint, _) = client_endpoint_builder
+            .bind(&"[::]:0".parse().unwrap())
+            .unwrap();
+
+        Connection::new(
+            client_endpoint
+                .connect(&addr, "localhost")
+                .unwrap()
+                .await
+                .unwrap(),
+        )
+    }
+}
+
+pub struct Server {
+    incoming: Incoming,
+}
+
+impl Server {
+    pub async fn next(&mut self) -> impl quic::Connection<Bytes> {
+        Connection::new(self.incoming.next().await.unwrap().await.unwrap())
+    }
+}
+
+pub fn build_certs() -> (CertificateChain, Certificate, PrivateKey) {
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+    let key = PrivateKey::from_der(&cert.serialize_private_key_der()).unwrap();
+    let cert = Certificate::from_der(&cert.serialize_der().unwrap()).unwrap();
+    (CertificateChain::from_certs(vec![cert.clone()]), cert, key)
+}

--- a/tests/h3-tests/tests/connection.rs
+++ b/tests/h3-tests/tests/connection.rs
@@ -1,0 +1,21 @@
+use h3::{client, server};
+use h3_tests::Pair;
+
+#[tokio::test]
+async fn connect() {
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        let _client = client::Connection::new(pair.client().await)
+            .await
+            .expect("client init");
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let _incoming_req = server::Connection::new(conn).await.unwrap();
+    };
+
+    tokio::join!(server_fut, client_fut);
+}

--- a/tests/h3-tests/tests/request.rs
+++ b/tests/h3-tests/tests/request.rs
@@ -1,0 +1,221 @@
+use h3::{client, server};
+use http::{HeaderMap, Request, Response, StatusCode};
+
+use h3_tests::Pair;
+
+#[tokio::test]
+async fn get() {
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        let mut client = client::Connection::new(pair.client().await)
+            .await
+            .expect("client init");
+        let mut request_stream = client
+            .send_request(Request::get("http://localhost/salut").body(()).unwrap())
+            .await
+            .expect("request");
+
+        let response = request_stream.recv_response().await.expect("recv response");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = request_stream
+            .recv_data()
+            .await
+            .expect("recv data")
+            .expect("body");
+        assert_eq!(body.as_ref(), b"wonderful hypertext");
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+
+        let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
+        request_stream
+            .send_response(
+                Response::builder()
+                    .status(200)
+                    .body(())
+                    .expect("build response"),
+            )
+            .await
+            .expect("send_response");
+        request_stream
+            .send_data("wonderful hypertext".into())
+            .await
+            .expect("send_data");
+        request_stream.finish().await.expect("finish");
+    };
+
+    tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn get_with_trailers_unknown_content_type() {
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        let mut client = client::Connection::new(pair.client().await)
+            .await
+            .expect("client init");
+        let mut request_stream = client
+            .send_request(Request::get("http://localhost/salut").body(()).unwrap())
+            .await
+            .expect("request");
+        request_stream.recv_response().await.expect("recv response");
+        request_stream
+            .recv_data()
+            .await
+            .expect("recv data")
+            .expect("body");
+
+        assert!(request_stream.recv_data().await.unwrap().is_none());
+        let trailers = request_stream
+            .recv_trailers()
+            .await
+            .expect("recv trailers")
+            .expect("trailers none");
+        assert_eq!(trailers.get("trailer").unwrap(), &"value");
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+
+        let (_, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
+        request_stream
+            .send_response(
+                Response::builder()
+                    .status(200)
+                    .body(())
+                    .expect("build response"),
+            )
+            .await
+            .expect("send_response");
+        request_stream
+            .send_data("wonderful hypertext".into())
+            .await
+            .expect("send_data");
+        let mut trailers = HeaderMap::new();
+        trailers.insert("trailer", "value".parse().unwrap());
+        request_stream
+            .send_trailers(trailers)
+            .await
+            .expect("send_trailers");
+        request_stream.finish().await.expect("finish");
+    };
+
+    tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn get_with_trailers_known_content_type() {
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        let mut client = client::Connection::new(pair.client().await)
+            .await
+            .expect("client init");
+        let mut request_stream = client
+            .send_request(Request::get("http://localhost/salut").body(()).unwrap())
+            .await
+            .expect("request");
+        request_stream.recv_response().await.expect("recv response");
+        request_stream
+            .recv_data()
+            .await
+            .expect("recv data")
+            .expect("body");
+
+        let trailers = request_stream
+            .recv_trailers()
+            .await
+            .expect("recv trailers")
+            .expect("trailers none");
+        assert_eq!(trailers.get("trailer").unwrap(), &"value");
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+
+        let (_, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
+        request_stream
+            .send_response(
+                Response::builder()
+                    .status(200)
+                    .body(())
+                    .expect("build response"),
+            )
+            .await
+            .expect("send_response");
+        request_stream
+            .send_data("wonderful hypertext".into())
+            .await
+            .expect("send_data");
+
+        let mut trailers = HeaderMap::new();
+        trailers.insert("trailer", "value".parse().unwrap());
+        request_stream
+            .send_trailers(trailers)
+            .await
+            .expect("send_trailers");
+        request_stream.finish().await.expect("finish");
+    };
+
+    tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn post() {
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        let mut client = client::Connection::new(pair.client().await)
+            .await
+            .expect("client init");
+        let mut request_stream = client
+            .send_request(Request::get("http://localhost/salut").body(()).unwrap())
+            .await
+            .expect("request");
+
+        request_stream
+            .send_data("wonderful json".into())
+            .await
+            .expect("send_data");
+        request_stream.finish().await.expect("client finish");
+
+        request_stream.recv_response().await.expect("recv response");
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+
+        let (_, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
+        request_stream
+            .send_response(
+                Response::builder()
+                    .status(200)
+                    .body(())
+                    .expect("build response"),
+            )
+            .await
+            .expect("send_response");
+
+        let request_body = request_stream
+            .recv_data()
+            .await
+            .expect("recv data")
+            .expect("server recv body");
+        assert_eq!(request_body, "wonderful json");
+        request_stream.finish().await.expect("client finish");
+    };
+
+    tokio::join!(server_fut, client_fut);
+}


### PR DESCRIPTION
Adresses #20.

I had to introduce stateless header compresison / decompression in `qpack::{en,de}code_stateless()` to prevent sharing state between `Connection` and `RequestStream`s for now. This code might also be useful later when we'll implement stateful dynamic QPACK.

I struggled to keep the `B: Buf` type argument of `RequestStream<C, B>` but couldn't help. I had to fix most of those to `Bytes`. I guess this is because the implementation manipulates buffers with `Bytes` and `BytesMut` in some places. Feels like I need some help figuring out what I'm missing here.

Maybe `send_data()` methods could accept `T: AsRef<&[u8]>` instread of `B` to make it more ergonomic ?

~~Some methods are exactly the same in `client` and `server` `RequestStream`, yet `send_response()` and `recv_request()` prevent to trivially de-duplicate those. I'll try to do this using another type parameter, like:~~ (DONE)

```rust
// Common impl block
impl<S, T> RequestStream<FrameStream<S>, Bytes, T>
where
    S: quic::RecvStream,
{
    pub async fn recv_data(&mut self) -> Result<Option<Bytes>, Error> {}
    pub async fn recv_trailers(&mut self) -> Result<Option<HeaderMap>, Error> {}
}

// Client's impl block
impl<S> RequestStream<FrameStream<S>, Bytes, Client>
where
    S: quic::RecvStream,
{
    pub async fn recv_response(&mut self) -> Result<Response<()>, Error> {}
}
```

I tried to reproduce `h2`'s tests organization. It's only helpful because `h3` and `h3-quinn` `quic` implementation are separated for now. But the same constraints as `h2` will likely start to show up at some point, so starting like this makes sense to me.
