### PR TITLE
Treat reserved frame types as unknown frames

### DIFF
--- a/h3/src/frame/mod.rs
+++ b/h3/src/frame/mod.rs
@@ -7,6 +7,7 @@ use std::{
 
 use bytes::{Buf, Bytes, BytesMut};
 use futures::future;
+use tracing::trace;
 
 use crate::{
     proto::{
@@ -193,7 +194,8 @@ impl FrameDecoder {
         let (pos, decoded) = decode!(src, |cur| Frame::decode(cur));
 
         match decoded {
-            Err(frame::Error::UnknownFrame(_)) => {
+            Err(frame::Error::UnknownFrame(ty)) => {
+                trace!("ignore unknown frame {:?}", ty);
                 src.advance(pos);
                 self.expected = None;
                 Ok(None)

--- a/h3/src/proto/frame.rs
+++ b/h3/src/proto/frame.rs
@@ -29,7 +29,6 @@ pub enum Frame {
     Goaway(u64),
     MaxPushId(u64),
     DuplicatePush(u64),
-    Reserved,
 }
 
 impl Frame {
@@ -50,7 +49,6 @@ impl Frame {
             Frame::Goaway(id) => simple_frame_encode(FrameType::GOAWAY, *id, buf),
             Frame::MaxPushId(id) => simple_frame_encode(FrameType::MAX_PUSH_ID, *id, buf),
             Frame::DuplicatePush(id) => simple_frame_encode(FrameType::DUPLICATE_PUSH, *id, buf),
-            Frame::Reserved => (),
         }
     }
 
@@ -82,10 +80,6 @@ impl Frame {
             | FrameType::H2_PING
             | FrameType::H2_WINDOW_UPDATE
             | FrameType::H2_CONTINUATION => Err(Error::UnsupportedFrame(ty.0)),
-            t if t.0 > 0x21 && (t.0 - 0x21) % 0x1f == 0 => {
-                buf.advance(len as usize);
-                Ok(Frame::Reserved)
-            }
             _ => {
                 buf.advance(len as usize);
                 Err(Error::UnknownFrame(ty.0))
@@ -114,7 +108,6 @@ impl fmt::Display for Frame {
             Frame::Goaway(id) => write!(f, "GoAway({})", id),
             Frame::MaxPushId(id) => write!(f, "MaxPushId({})", id),
             Frame::DuplicatePush(id) => write!(f, "DuplicatePush({})", id),
-            Frame::Reserved => write!(f, "Reserved"),
         }
     }
 }
@@ -431,6 +424,6 @@ mod tests {
         raw.extend(&[6, 0, 255, 128, 0, 250, 218]);
         let mut buf = Cursor::new(&raw);
         let decoded = Frame::decode(&mut buf);
-        assert_eq!(decoded, Ok(Frame::Reserved));
+        assert_eq!(decoded, Err(Error::UnknownFrame(95)));
     }
 }


### PR DESCRIPTION
[Section 7.2.8](https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-7.2.8) says that "reserved" frames are meant to be treated as unknown frames.