### PR TITLE
Fix h3-quinn receiving of ordered data

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.40.0
+          - 1.42.0
 
     runs-on: ubuntu-latest
 

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -206,11 +206,18 @@ impl<S: Session> quic::RecvStream for RecvStream<S> {
 
         match self.stream.read(&mut self.buf).poll_unpin(cx) {
             Poll::Ready(Ok(Some(n))) => {
+                eprintln!("stream read: {}", n);
                 let buf = self.buf.split_to(n).freeze();
                 Poll::Ready(Ok(Some(buf)))
             }
-            Poll::Ready(Ok(None)) => Poll::Ready(Ok(None)),
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+            Poll::Ready(Ok(None)) => {
+                eprintln!("stream read: None");
+                Poll::Ready(Ok(None))
+            }
+            Poll::Ready(Err(e)) => {
+                eprintln!("stream read error: {:?}", e);
+                Poll::Ready(Err(e.into()))
+            }
             Poll::Pending => Poll::Pending,
         }
     }

--- a/tests/h3-tests/Cargo.toml
+++ b/tests/h3-tests/Cargo.toml
@@ -12,6 +12,7 @@ rcgen = { version = "0.7.0" }
 bytes = "0.5.6"
 futures = "0.3"
 http = "0.2.1"
+tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["rt-threaded", "macros"]}

--- a/tests/h3-tests/src/lib.rs
+++ b/tests/h3-tests/src/lib.rs
@@ -11,6 +11,14 @@ use h3_quinn::{
     Connection,
 };
 
+pub fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::FULL)
+        .with_test_writer()
+        .try_init();
+}
+
 #[derive(Clone)]
 pub struct Pair {
     port: u16,

--- a/tests/h3-tests/tests/request.rs
+++ b/tests/h3-tests/tests/request.rs
@@ -5,6 +5,7 @@ use h3_tests::Pair;
 
 #[tokio::test]
 async fn get() {
+    h3_tests::init_tracing();
     let mut pair = Pair::new();
     let mut server = pair.server();
 
@@ -54,6 +55,7 @@ async fn get() {
 
 #[tokio::test]
 async fn get_with_trailers_unknown_content_type() {
+    h3_tests::init_tracing();
     let mut pair = Pair::new();
     let mut server = pair.server();
 
@@ -113,6 +115,7 @@ async fn get_with_trailers_unknown_content_type() {
 
 #[tokio::test]
 async fn get_with_trailers_known_content_type() {
+    h3_tests::init_tracing();
     let mut pair = Pair::new();
     let mut server = pair.server();
 
@@ -172,6 +175,7 @@ async fn get_with_trailers_known_content_type() {
 
 #[tokio::test]
 async fn post() {
+    h3_tests::init_tracing();
     let mut pair = Pair::new();
     let mut server = pair.server();
 


### PR DESCRIPTION
This fixes some bugs that existed due to the trickiness of unordered reads. With this change, I'm able to get the client example (#25) to download webpages. 