### PR TITLE
Make implementing BidiStream optional

### DIFF
--- a/h3/src/frame/mod.rs
+++ b/h3/src/frame/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         frame::{self, Frame},
         ErrorCode,
     },
-    quic::{BidiStream, RecvStream, SendStream},
+    quic::{RecvStream, SendStream},
 };
 use buf::BufList;
 
@@ -147,7 +147,7 @@ where
 
 impl<T, B> SendStream<B> for FrameStream<T>
 where
-    T: BidiStream<B>,
+    T: SendStream<B> + RecvStream,
     B: Buf,
 {
     type Error = <T as SendStream<B>>::Error;

--- a/h3/src/quic.rs
+++ b/h3/src/quic.rs
@@ -19,7 +19,10 @@ pub trait Connection<B: Buf> {
     type RecvStream: RecvStream;
     /// The stream type returned when accepting or opening a bidirectional
     /// stream.
-    type BidiStream: BidiStream<B> + SendStream<B> + RecvStream;
+    ///
+    /// This type doesn't *have* to implement `BidiStream`, but if the
+    /// implementation is able to provide a cheap split, it can opt-in.
+    type BidiStream: SendStream<B> + RecvStream;
     /// The error type that can be returned when accepting or opening a stream.
     type Error: Into<Box<dyn std::error::Error + Send + Sync>>;
 


### PR DESCRIPTION
I noticed that `BidiStream` is meant to be optional, to allow implementations that *can* split their streams to do so, but shouldn't be required.