### PR TITLE
Fix unexpected ends when skipping a grease frame

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -5,6 +5,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .with_span_events(tracing_subscriber::fmt::format::FmtSpan::FULL)
+        .with_writer(std::io::stderr)
         .init();
 
     let dest = std::env::args()

--- a/h3/src/proto/frame.rs
+++ b/h3/src/proto/frame.rs
@@ -138,10 +138,15 @@ frame_types! {
 pub(crate) struct FrameType(u64);
 
 impl FrameType {
+    #[cfg(test)]
+    pub(crate) const RESERVED: FrameType = FrameType(0x1f * 1337 + 0x21);
+}
+
+impl FrameType {
     fn decode<B: Buf>(buf: &mut B) -> Result<Self, UnexpectedEnd> {
         Ok(FrameType(buf.get_var()?))
     }
-    fn encode<B: BufMut>(&self, buf: &mut B) {
+    pub(crate) fn encode<B: BufMut>(&self, buf: &mut B) {
         buf.write_var(self.0);
     }
 }


### PR DESCRIPTION
I noticed trying to use the client example to connect to `https://quic.tech:8443` that it would fail with an `UnexpectedEnd` error. This happens because the stream data is small, and able to fit two GREASE frames and then a final DATA frame.

The previous `decode` would assume that since it was the final frame, but there was still data left, it had ended unexpectedly. The fix is to make `decode` loop since it may ignore unknown frames.