### PR TITLE
Update quinn and h3-29

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.42.0
+          - 1.45.0
 
     runs-on: ubuntu-latest
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // quinn setup
     let mut client_config = h3_quinn::quinn::ClientConfigBuilder::default();
-    client_config.protocols(&[b"h3-27"]);
+    client_config.protocols(&[b"h3-29"]);
 
     let mut client_endpoint_builder = h3_quinn::quinn::Endpoint::builder();
     client_endpoint_builder.default_client_config(client_config.build());

--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 h3 = { path = "../h3" }
 bytes = "0.5"
-quinn = "0.6"
-quinn-proto = "0.6"
+quinn = { git ="https://github.com/quinn-rs/quinn.git", branch="main" }
+quinn-proto = { git ="https://github.com/quinn-rs/quinn.git", branch="main" }
 futures = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Currently running the client against popular endpoint such as google.com would result in a version mismatch failure. Using the updated version of quinn fixes it.

```
client https://google.com
DNS Lookup for https://google.com/: [2607:f8b0:400a:803::200e]:443
QUIC connected ...
Sending request ...
Receiving response ...
Response: HTTP/3.0 301 Moved Permanently
Headers: {
    "location": "https://www.google.com/",
    "content-type": "text/html; charset=UTF-8",
    "date": "Fri, 15 Jan 2021 06:07:46 GMT",
    "expires": "Sun, 14 Feb 2021 06:07:46 GMT",
    "cache-control": "public, max-age=2592000",
    "server": "gws",
    "content-length": "220",
    "x-xss-protection": "0",
    "x-frame-options": "SAMEORIGIN",
    "alt-svc": "h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
}
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="https://www.google.com/">here</A>.
</BODY></HTML>
```