### PR TITLE
Accept unidirectionnal streams and ControlStream impl

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # If you copy one of the examples into a new project, you should be using
 # [dependencies] instead.
 [dev-dependencies]
+bytes = "1"
 futures = "0.3"
 http = "0.2"
 h3 = { path = "../h3" }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // quinn setup
     let mut server_config = h3_quinn::quinn::ServerConfigBuilder::default();
-    server_config.protocols(&[b"h3-27"]);
+    server_config.protocols(&[b"h3-29"]);
 
     let (endpoint, mut incoming) = match opt.command {
         Command::SelfSigned(r) => {

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -11,8 +11,8 @@ use futures::{ready, FutureExt, StreamExt};
 
 use bytes::{Buf, Bytes};
 use h3::quic;
-pub use quinn;
-use quinn::{
+pub use quinn::{
+    self,
     crypto::Session,
     generic::{IncomingBiStreams, IncomingUniStreams, NewConnection, OpenBi, OpenUni},
     ConnectionError, VarInt, WriteError,

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -145,6 +145,14 @@ where
         self.recv.poll_data(cx)
     }
 
+    fn poll_read(
+        &mut self,
+        buf: &mut [u8],
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Option<usize>, Self::Error>> {
+        self.recv.poll_read(buf, cx)
+    }
+
     fn stop_sending(&mut self, error_code: u64) {
         self.recv.stop_sending(error_code)
     }
@@ -201,6 +209,14 @@ impl<S: Session> quic::RecvStream for RecvStream<S> {
             .read_chunk(usize::MAX, true)
             .poll_unpin(cx))?
         .map(|c| (c.bytes))))
+    }
+
+    fn poll_read(
+        &mut self,
+        buf: &mut [u8],
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Option<usize>, Self::Error>> {
+        Poll::Ready(Ok(ready!(self.stream.read(buf).poll_unpin(cx))?))
     }
 
     fn stop_sending(&mut self, error_code: u64) {

--- a/h3/Cargo.toml
+++ b/h3/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Sean McArthur <sean@seanmonstar.com>", "Jean-Christophe BEGUE <jc.be
 license = "MIT"
 edition = "2018"
 
+[features]
+test_helpers = []
+
 [dependencies]
 bytes = "1"
 futures = "0.3"

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -1,11 +1,12 @@
 use std::{
     convert::TryFrom,
     marker::PhantomData,
+    sync::{Arc, RwLock},
     task::{Context, Poll},
 };
 
 use bytes::{Bytes, BytesMut};
-use futures::{future, ready};
+use futures::{channel::oneshot, future, ready};
 use http::HeaderMap;
 
 use crate::{
@@ -20,10 +21,29 @@ use crate::{
     stream::{AcceptRecvStream, AcceptedRecvStream},
 };
 
-pub(super) struct ConnectionInner<C>
+#[derive(Clone)]
+#[doc(hidden)]
+pub struct SharedState {
+    pub peer_max_field_section_size: u64, // maximum size for a header we send
+}
+
+#[derive(Clone)]
+#[doc(hidden)]
+pub struct SharedStateRef(pub Arc<RwLock<SharedState>>);
+
+impl Default for SharedStateRef {
+    fn default() -> Self {
+        Self(Arc::new(RwLock::new(SharedState {
+            peer_max_field_section_size: VarInt::MAX.0,
+        })))
+    }
+}
+
+pub struct ConnectionInner<C>
 where
     C: quic::Connection<Bytes>,
 {
+    pub(super) shared: SharedStateRef,
     conn: C,
     max_field_section_size: u64,
     peer_max_field_section_size: u64,
@@ -31,13 +51,18 @@ where
     control_recv: Option<FrameStream<C::RecvStream>>,
     pending_recv_streams: Vec<AcceptRecvStream<C::RecvStream>>,
     got_peer_settings: bool,
+    request_close_receivers: Vec<oneshot::Receiver<()>>,
 }
 
 impl<C> ConnectionInner<C>
 where
     C: quic::Connection<Bytes>,
 {
-    pub async fn new(mut conn: C, max_field_section_size: u64) -> Result<Self, Error> {
+    pub async fn new(
+        mut conn: C,
+        max_field_section_size: u64,
+        shared: SharedStateRef,
+    ) -> Result<Self, Error> {
         let mut control_send = future::poll_fn(|mut cx| conn.poll_open_send(&mut cx))
             .await
             .map_err(|e| Code::H3_STREAM_CREATION_ERROR.with_cause(e))?;
@@ -51,6 +76,7 @@ where
         stream::write(&mut control_send, Frame::Settings(settings)).await?;
 
         Ok(Self {
+            shared,
             conn,
             control_send,
             max_field_section_size,
@@ -58,6 +84,7 @@ where
             control_recv: None,
             pending_recv_streams: Vec::with_capacity(3),
             got_peer_settings: false,
+            request_close_receivers: Vec::new(),
         })
     }
 
@@ -116,24 +143,21 @@ where
         let res = match recvd {
             None => Err(Code::H3_CLOSED_CRITICAL_STREAM.with_reason("control stream closed")),
             Some(frame) => match frame {
-                Frame::Settings(settings) => {
-                    if self.got_peer_settings {
-                        Err(Code::H3_FRAME_UNEXPECTED
-                            .with_reason("settings frame already received"))
-                    } else {
-                        self.got_peer_settings = true;
-                        self.peer_max_field_section_size = settings
-                            .get(SettingId::MAX_HEADER_LIST_SIZE)
-                            .unwrap_or(VarInt::MAX.0);
-                        Ok(Frame::Settings(settings))
-                    }
+                Frame::Settings(settings) if !self.got_peer_settings => {
+                    self.got_peer_settings = true;
+                    self.shared
+                        .0
+                        .write()
+                        .expect("connection settings write")
+                        .peer_max_field_section_size = settings
+                        .get(SettingId::MAX_HEADER_LIST_SIZE)
+                        .unwrap_or(VarInt::MAX.0);
+                    Ok(Frame::Settings(settings))
                 }
-                f @ Frame::CancelPush(_) | f @ Frame::Goaway(_) | f @ Frame::MaxPushId(_) => {
-                    if self.got_peer_settings {
-                        Ok(f)
-                    } else {
-                        Err(Code::H3_MISSING_SETTINGS.into())
-                    }
+                Frame::CancelPush(_) | Frame::MaxPushId(_) | Frame::Goaway(_)
+                    if !self.got_peer_settings =>
+                {
+                    Err(Code::H3_MISSING_SETTINGS.into())
                 }
                 frame => Err(Code::H3_FRAME_UNEXPECTED
                     .with_reason(format!("on control stream: {:?}", frame))),
@@ -143,35 +167,20 @@ where
     }
 }
 
-pub struct Builder<T> {
-    pub(super) max_field_section_size: u64,
-    phtantom: PhantomData<T>,
-}
-
-impl<T> Builder<T> {
-    pub(super) fn new() -> Self {
-        Builder {
-            max_field_section_size: 0, // Unlimited
-            phtantom: PhantomData,
-        }
-    }
-
-    pub fn max_field_section_size(&mut self, value: u64) -> &mut Self {
-        self.max_field_section_size = value;
-        self
-    }
-}
-
 pub struct RequestStream<S, B> {
     pub(super) stream: S,
     pub(super) trailers: Option<Bytes>,
+    pub(super) conn_state: SharedStateRef,
+    pub(super) max_field_section_size: u64,
     _phantom_buffer: PhantomData<B>,
 }
 
 impl<S, B> RequestStream<S, B> {
-    pub fn new(stream: S) -> Self {
+    pub fn new(stream: S, max_field_section_size: u64, conn_state: SharedStateRef) -> Self {
         Self {
             stream,
+            conn_state,
+            max_field_section_size,
             trailers: None,
             _phantom_buffer: PhantomData,
         }
@@ -211,9 +220,16 @@ where
             }
         };
 
-        Ok(Some(
-            Header::try_from(qpack::decode_stateless(&mut trailers)?)?.into_fields(),
-        ))
+        let (fields, mem_size) = qpack::decode_stateless(&mut trailers)?;
+        if mem_size > self.max_field_section_size {
+            return Err(Error::header_too_big(mem_size, self.max_field_section_size));
+        }
+
+        Ok(Some(Header::try_from(fields)?.into_fields()))
+    }
+
+    pub fn stop_sending(&mut self, err_code: Code) {
+        self.stream.stop_sending(err_code);
     }
 }
 
@@ -243,7 +259,16 @@ where
     /// Send a set of trailers to end the request.
     pub async fn send_trailers(&mut self, trailers: HeaderMap) -> Result<(), Error> {
         let mut block = BytesMut::new();
-        qpack::encode_stateless(&mut block, Header::trailer(trailers))?;
+        let mem_size = qpack::encode_stateless(&mut block, Header::trailer(trailers))?;
+        let max_mem_size = self
+            .conn_state
+            .0
+            .read()
+            .expect("send_trailers shared state read")
+            .peer_max_field_section_size;
+        if mem_size > max_mem_size {
+            return Err(Error::header_too_big(mem_size, max_mem_size));
+        }
 
         stream::write(&mut self.stream, Frame::Headers(block.freeze())).await?;
 

--- a/h3/src/frame/mod.rs
+++ b/h3/src/frame/mod.rs
@@ -507,6 +507,14 @@ mod tests {
             Poll::Ready(Ok(self.chunks.pop_front()))
         }
 
+        fn poll_read(
+            &mut self,
+            _buf: &mut [u8],
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<Option<usize>, Self::Error>> {
+            todo!();
+        }
+
         fn stop_sending(&mut self, _: u64) {
             unimplemented!()
         }

--- a/h3/src/lib.rs
+++ b/h3/src/lib.rs
@@ -10,5 +10,6 @@ mod frame;
 mod proto;
 #[allow(dead_code)]
 mod qpack;
+mod stream;
 
 pub use error::Error;

--- a/h3/src/proto/frame.rs
+++ b/h3/src/proto/frame.rs
@@ -272,7 +272,7 @@ impl FrameHeader for Settings {
 }
 
 impl Settings {
-    fn insert(&mut self, id: SettingId, value: u64) -> Result<(), SettingsError> {
+    pub fn insert(&mut self, id: SettingId, value: u64) -> Result<(), SettingsError> {
         if self.len >= self.entries.len() {
             return Err(SettingsError::Exceeded);
         }
@@ -288,6 +288,15 @@ impl Settings {
         self.entries[self.len] = (id, value);
         self.len += 1;
         Ok(())
+    }
+
+    pub fn get(&self, id: SettingId) -> Option<u64> {
+        for (entry_id, value) in self.entries.iter() {
+            if id == *entry_id {
+                return Some(*value);
+            }
+        }
+        None
     }
 
     pub(super) fn encode<T: BufMut>(&self, buf: &mut T) {

--- a/h3/src/proto/headers.rs
+++ b/h3/src/proto/headers.rs
@@ -85,6 +85,10 @@ impl Header {
         self.pseudo.len() + self.fields.len()
     }
 
+    pub fn size(&self) -> usize {
+        self.pseudo.len() + self.fields.len()
+    }
+
     #[cfg(test)]
     pub(crate) fn authory_mut(&mut self) -> &mut Option<Authority> {
         &mut self.pseudo.authority

--- a/h3/src/proto/mod.rs
+++ b/h3/src/proto/mod.rs
@@ -3,4 +3,5 @@ pub mod coding;
 pub mod frame;
 #[allow(dead_code)]
 pub mod headers;
+pub mod stream;
 pub mod varint;

--- a/h3/src/proto/stream.rs
+++ b/h3/src/proto/stream.rs
@@ -1,0 +1,45 @@
+use bytes::{Buf, BufMut};
+use std::fmt;
+
+use super::coding::{BufExt, BufMutExt, Decode, Encode, UnexpectedEnd};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct StreamType(pub u64);
+
+macro_rules! stream_types {
+    {$($name:ident = $val:expr,)*} => {
+        impl StreamType {
+            $(pub const $name: StreamType = StreamType($val);)*
+        }
+    }
+}
+
+stream_types! {
+    CONTROL = 0x00,
+    PUSH = 0x01,
+    ENCODER = 0x02,
+    DECODER = 0x03,
+}
+
+impl Decode for StreamType {
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self, UnexpectedEnd> {
+        Ok(StreamType(buf.get_var()?))
+    }
+}
+
+impl Encode for StreamType {
+    fn encode<W: BufMut>(&self, buf: &mut W) {
+        buf.write_var(self.0);
+    }
+}
+
+impl fmt::Display for StreamType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            &StreamType::CONTROL => write!(f, "Control"),
+            &StreamType::ENCODER => write!(f, "Encoder"),
+            &StreamType::DECODER => write!(f, "Decoder"),
+            x => write!(f, "StreamType({})", x.0),
+        }
+    }
+}

--- a/h3/src/qpack/encoder.rs
+++ b/h3/src/qpack/encoder.rs
@@ -187,12 +187,14 @@ impl Encoder {
     }
 }
 
-pub fn encode_stateless<W, T, H>(block: &mut W, fields: T) -> Result<(), Error>
+pub fn encode_stateless<W, T, H>(block: &mut W, fields: T) -> Result<u64, Error>
 where
     W: BufMut,
     T: IntoIterator<Item = H>,
     H: AsRef<HeaderField>,
 {
+    let mut size = 0;
+
     HeaderPrefix::new(0, 0, 0, 0).encode(block);
     for field in fields {
         let field = field.as_ref();
@@ -204,8 +206,10 @@ where
         } else {
             Literal::new(field.name.clone(), field.value.clone()).encode(block)?;
         }
+
+        size += field.mem_size() as u64;
     }
-    Ok(())
+    Ok(size)
 }
 
 #[cfg(test)]

--- a/h3/src/quic.rs
+++ b/h3/src/quic.rs
@@ -96,6 +96,17 @@ pub trait RecvStream {
         cx: &mut task::Context<'_>,
     ) -> Poll<Result<Option<Self::Buf>, Self::Error>>;
 
+    /// Poll the stream for a precise number of bytes
+    ///
+    /// The `buf` slice should be filled with as much received data as possible. When
+    /// the receive side will no longer receive more data (such as because
+    /// the peer closed their sending side), this should return `None`.
+    fn poll_read(
+        &mut self,
+        buf: &mut [u8],
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Option<usize>, Self::Error>>;
+
     /// Send a `STOP_SENDING` QUIC code.
     fn stop_sending(&mut self, error_code: u64);
 }

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -1,0 +1,137 @@
+use std::{
+    io,
+    task::{Context, Poll},
+};
+
+use bytes::{Bytes, BytesMut};
+use futures::{future, ready};
+use quic::RecvStream;
+
+use crate::{
+    error::Code,
+    frame::FrameStream,
+    proto::{
+        coding::{BufExt, Decode as _, Encode},
+        stream::StreamType,
+        varint::VarInt,
+    },
+    quic::{self, SendStream},
+    Error,
+};
+
+pub(crate) async fn write<S, T>(stream: &mut S, data: T) -> Result<(), Error>
+where
+    S: SendStream<Bytes>,
+    T: Encode,
+{
+    let mut buf = BytesMut::new();
+    data.encode(&mut buf);
+
+    stream
+        .send_data(buf.freeze())
+        .map_err(|e| Error::transport(e.into()))?;
+
+    future::poll_fn(|cx| stream.poll_ready(cx))
+        .await
+        .map_err(|e| Error::transport(e.into()))?;
+
+    Ok(())
+}
+
+pub(super) enum AcceptedRecvStream<S>
+where
+    S: quic::RecvStream,
+{
+    Control(FrameStream<S>),
+    Push(u64, FrameStream<S>),
+    Encoder(S),
+    Decoder(S),
+    Reserved,
+}
+
+pub(super) struct AcceptRecvStream<S>
+where
+    S: quic::RecvStream,
+{
+    stream: S,
+    ty: Option<StreamType>,
+    push_id: Option<u64>,
+    buf: [u8; VarInt::MAX_SIZE],
+    expected: usize,
+    len: usize,
+}
+
+impl<S> AcceptRecvStream<S>
+where
+    S: RecvStream,
+{
+    pub fn new(stream: S) -> Self {
+        Self {
+            stream,
+            ty: None,
+            push_id: None,
+            buf: [0; VarInt::MAX_SIZE],
+            expected: 1,
+            len: 0,
+        }
+    }
+
+    pub fn into_stream(self) -> Result<AcceptedRecvStream<S>, Error> {
+        Ok(match self.ty.expect("Stream type not resolved yet") {
+            StreamType::CONTROL => AcceptedRecvStream::Control(FrameStream::new(self.stream)),
+            StreamType::PUSH => AcceptedRecvStream::Push(
+                self.push_id.expect("Push ID not resolved yet"),
+                FrameStream::new(self.stream),
+            ),
+            StreamType::ENCODER => AcceptedRecvStream::Encoder(self.stream),
+            StreamType::DECODER => AcceptedRecvStream::Decoder(self.stream),
+            t if t.0 > 0x21 && (t.0 - 0x21) % 0x1f == 0 => AcceptedRecvStream::Reserved,
+            t => {
+                return Err(Code::H3_STREAM_CREATION_ERROR
+                    .with_reason(format!("unknown stream type 0x{:x}", t.0)))
+            }
+        })
+    }
+
+    pub fn poll_type(&mut self, cx: &mut Context) -> Poll<Result<(), Error>> {
+        loop {
+            match (self.ty.as_ref(), self.push_id) {
+                (Some(&StreamType::PUSH), Some(_)) | (Some(_), _) => return Poll::Ready(Ok(())),
+                _ => (),
+            }
+
+            match ready!(self
+                .stream
+                .poll_read(&mut self.buf[self.len..self.expected], cx))
+            .map_err(Error::transport)?
+            {
+                Some(s) => self.len += s,
+                None => {
+                    return Poll::Ready(Err(Code::H3_STREAM_CREATION_ERROR
+                        .with_reason("Stream closed before type received")))
+                }
+            };
+
+            if self.len == 1 {
+                self.expected = VarInt::encoded_size(self.buf[0]);
+            }
+            if self.len < self.expected {
+                continue;
+            }
+
+            let mut cur = io::Cursor::new(&self.buf);
+            if self.ty.is_none() {
+                self.ty = Some(StreamType::decode(&mut cur).map_err(|_| {
+                    Code::H3_INTERNAL_ERROR.with_reason("Unexpected end parsing stream type")
+                })?);
+                // Get the next VarInt for PUSH_ID on the next iteration
+                self.len = 0;
+                self.expected = 1;
+            } else {
+                self.push_id = Some(cur.get_var().map_err(|_| {
+                    Code::H3_INTERNAL_ERROR.with_reason("Unexpected end parsing stream type")
+                })?);
+            }
+        }
+    }
+}

--- a/tests/h3-tests/Cargo.toml
+++ b/tests/h3-tests/Cargo.toml
@@ -6,13 +6,14 @@ publish = false
 edition = "2018"
 
 [dependencies]
-h3 = { path = "../../h3" }
+h3 = { path = "../../h3", features = ["test_helpers"]}
 h3-quinn = { path = "../../h3-quinn" }
 rcgen = { version = "0.7.0" }
 bytes = "1"
 futures = "0.3"
 http = "0.2.1"
 tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }
+assert_matches = "1.5"
 
 [dev-dependencies]
 tokio = "1"

--- a/tests/h3-tests/tests/connection.rs
+++ b/tests/h3-tests/tests/connection.rs
@@ -1,5 +1,7 @@
+use futures::future;
 use h3::{client, server};
 use h3_tests::Pair;
+use std::time::Duration;
 
 #[tokio::test]
 async fn connect() {
@@ -16,4 +18,83 @@ async fn connect() {
     };
 
     tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn settings_exchange_client() {
+    h3_tests::init_tracing();
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        let (mut conn, client) = client::new(pair.client().await).await.expect("client init");
+        let settings_change = async {
+            for _ in 0..10 {
+                if client.state().0.read().unwrap().peer_max_field_section_size == 12 {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }
+            panic!("peer's max_field_section_size didn't change");
+        };
+
+        let drive = async move {
+            future::poll_fn(|cx| conn.poll_close(cx)).await.unwrap();
+        };
+
+        tokio::select! { _ = settings_change => (), _ = drive => panic!("driver resolved first") };
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming = server::Connection::builder()
+            .max_field_section_size(12)
+            .build(conn)
+            .await
+            .unwrap();
+        incoming.accept().await.unwrap()
+    };
+
+    tokio::select! { _ = server_fut => panic!("server resolved first"), _ = client_fut => () };
+}
+
+#[tokio::test]
+async fn settings_exchange_server() {
+    h3_tests::init_tracing();
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        let (mut conn, _client) = client::builder()
+            .max_field_section_size(12)
+            .build(pair.client().await)
+            .await
+            .expect("client init");
+        let drive = async move {
+            future::poll_fn(|cx| conn.poll_close(cx)).await.unwrap();
+        };
+
+        tokio::select! { _ = drive => () };
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming = server::Connection::new(conn).await.unwrap();
+
+        let state = incoming.state().clone();
+        let accept = async { incoming.accept().await.unwrap() };
+
+        let settings_change = async {
+            for _ in 0..10 {
+                if state.0.read().unwrap().peer_max_field_section_size == 12 {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }
+            panic!("peer's max_field_section_size didn't change");
+        };
+        tokio::select! { _ = accept => panic!("server resolved first"), _ = settings_change => () };
+    };
+
+    tokio::select! { _ = server_fut => (), _ = client_fut => () };
 }

--- a/tests/h3-tests/tests/connection.rs
+++ b/tests/h3-tests/tests/connection.rs
@@ -7,14 +7,12 @@ async fn connect() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let _client = client::Connection::new(pair.client().await)
-            .await
-            .expect("client init");
+        let _ = client::new(pair.client().await).await.expect("client init");
     };
 
     let server_fut = async {
         let conn = server.next().await;
-        let _incoming_req = server::Connection::new(conn).await.unwrap();
+        let _ = server::Connection::new(conn).await.unwrap();
     };
 
     tokio::join!(server_fut, client_fut);

--- a/tests/h3-tests/tests/request.rs
+++ b/tests/h3-tests/tests/request.rs
@@ -1,6 +1,13 @@
-use h3::{client, server};
+use std::{error::Error as _, time::Duration};
+
+use assert_matches::assert_matches;
 use http::{HeaderMap, Request, Response, StatusCode};
 
+use h3::{
+    client,
+    error::{Code, Kind},
+    server,
+};
 use h3_tests::Pair;
 
 #[tokio::test]
@@ -211,6 +218,491 @@ async fn post() {
             .expect("server recv body");
         assert_eq!(request_body, "wonderful json");
         request_stream.finish().await.expect("client finish");
+    };
+
+    tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn header_too_big_response_from_server() {
+    h3_tests::init_tracing();
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        // Do not poll driver so client doesn't know about server's max_field section size setting
+        let (_conn, mut client) = client::new(pair.client().await).await.expect("client init");
+        let mut request_stream = client
+            .send_request(Request::get("http://localhost/salut").body(()).unwrap())
+            .await
+            .expect("request");
+        request_stream.finish().await.expect("client finish");
+        let response = request_stream.recv_response().await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE
+        );
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming_req = server::Connection::builder()
+            .max_field_section_size(12)
+            .build(conn)
+            .await
+            .unwrap();
+
+        let err_kind = incoming_req.accept().await.map(|_| ()).unwrap_err().kind();
+        assert_matches!(
+            err_kind,
+            Kind::HeaderTooBig {
+                actual_size: 179,
+                max_size: 12,
+            }
+        );
+        let _ = incoming_req.accept().await;
+    };
+
+    tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn header_too_big_response_from_server_trailers() {
+    h3_tests::init_tracing();
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        // Do not poll driver so client doesn't know about server's max_field_section_size setting
+        let (_conn, mut client) = client::new(pair.client().await).await.expect("client init");
+        let mut request_stream = client
+            .send_request(Request::get("http://localhost/salut").body(()).unwrap())
+            .await
+            .expect("request");
+        request_stream
+            .send_data("wonderful json".into())
+            .await
+            .expect("send_data");
+
+        let mut trailers = HeaderMap::new();
+        trailers.insert("trailer", "A".repeat(200).parse().unwrap());
+        request_stream
+            .send_trailers(trailers)
+            .await
+            .expect("send trailers");
+        request_stream.finish().await.expect("client finish");
+
+        let response = request_stream.recv_response().await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE
+        );
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming_req = server::Connection::builder()
+            .max_field_section_size(207)
+            .build(conn)
+            .await
+            .unwrap();
+
+        let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
+        let _ = request_stream
+            .recv_data()
+            .await
+            .expect("recv data")
+            .expect("body");
+        let err_kind = request_stream.recv_trailers().await.unwrap_err().kind();
+        assert_matches!(
+            err_kind,
+            Kind::HeaderTooBig {
+                actual_size: 239,
+                max_size: 207,
+            }
+        );
+        let _ = incoming_req.accept().await;
+    };
+
+    tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn header_too_big_client_error() {
+    h3_tests::init_tracing();
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        let (_, mut client) = client::new(pair.client().await).await.expect("client init");
+        // pretend client already received server's settings
+        client
+            .state()
+            .0
+            .write()
+            .unwrap()
+            .peer_max_field_section_size = 12;
+
+        let req = Request::get("http://localhost/salut").body(()).unwrap();
+        let err_kind = client
+            .send_request(req)
+            .await
+            .map(|_| ())
+            .unwrap_err()
+            .kind();
+        assert_matches!(
+            err_kind,
+            Kind::HeaderTooBig {
+                actual_size: 179,
+                max_size: 12,
+            }
+        );
+    };
+
+    let server_fut = async {
+        server.next().await;
+    };
+
+    tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn header_too_big_client_error_trailer() {
+    h3_tests::init_tracing();
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        // Do not poll driver so client doesn't know about server's max_field_section_size setting
+        let (_conn, mut client) = client::new(pair.client().await).await.expect("client init");
+        client
+            .state()
+            .0
+            .write()
+            .unwrap()
+            .peer_max_field_section_size = 200;
+
+        let mut request_stream = client
+            .send_request(Request::get("http://localhost/salut").body(()).unwrap())
+            .await
+            .expect("request");
+        request_stream
+            .send_data("wonderful json".into())
+            .await
+            .expect("send_data");
+
+        let mut trailers = HeaderMap::new();
+        trailers.insert("trailer", "A".repeat(200).parse().unwrap());
+
+        let err_kind = request_stream
+            .send_trailers(trailers)
+            .await
+            .unwrap_err()
+            .kind();
+        assert_matches!(
+            err_kind,
+            Kind::HeaderTooBig {
+                actual_size: 239,
+                max_size: 200,
+            }
+        );
+
+        request_stream.finish().await.expect("client finish");
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming_req = server::Connection::builder()
+            .max_field_section_size(207)
+            .build(conn)
+            .await
+            .unwrap();
+
+        let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
+        let _ = request_stream
+            .recv_data()
+            .await
+            .expect("recv data")
+            .expect("body");
+        let _ = incoming_req.accept().await;
+    };
+
+    tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn header_too_big_discard_from_client() {
+    h3_tests::init_tracing();
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        // Do not poll driver so client doesn't know about server's max_field section size setting
+        let (_conn, mut client) = client::builder()
+            .max_field_section_size(12)
+            .build(pair.client().await)
+            .await
+            .expect("client init");
+        let mut request_stream = client
+            .send_request(Request::get("http://localhost/salut").body(()).unwrap())
+            .await
+            .expect("request");
+        request_stream.finish().await.expect("client finish");
+        let err_kind = request_stream.recv_response().await.unwrap_err().kind();
+        assert_matches!(
+            err_kind,
+            Kind::HeaderTooBig {
+                actual_size: 42,
+                max_size: 12,
+            }
+        );
+
+        let mut request_stream = client
+            .send_request(Request::get("http://localhost/salut").body(()).unwrap())
+            .await
+            .expect("request");
+        request_stream.finish().await.expect("client finish");
+        let _ = request_stream.recv_response().await.unwrap_err();
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+
+        let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
+        // pretend server didn't receive settings
+        incoming_req
+            .state()
+            .0
+            .write()
+            .unwrap()
+            .peer_max_field_section_size = u64::MAX;
+        request_stream
+            .send_response(
+                Response::builder()
+                    .status(200)
+                    .body(())
+                    .expect("build response"),
+            )
+            .await
+            .expect("send_response");
+
+        // Keep sending: wait for the stream to be cancelled by the client
+        let mut err = None;
+        for _ in 0..100 {
+            if let Err(e) = request_stream.send_data("some data".into()).await {
+                err = Some(e);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        assert_matches!(err.as_ref().unwrap().kind(), Kind::Transport);
+        assert_matches!(err, Some(e) => {
+            assert_matches!(
+                e.source()
+                    .unwrap()
+                    .downcast_ref::<h3_quinn::SendStreamError>()
+                    .unwrap(),
+                h3_quinn::SendStreamError::Write(h3_quinn::quinn::WriteError::Stopped(c))
+                    if Code::H3_REQUEST_REJECTED == c.into_inner()
+            );
+        });
+        let _ = incoming_req.accept().await;
+    };
+
+    tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn header_too_big_discard_from_client_trailers() {
+    h3_tests::init_tracing();
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        // Do not poll driver so client doesn't know about server's max_field section size setting
+        let (_conn, mut client) = client::builder()
+            .max_field_section_size(200)
+            .build(pair.client().await)
+            .await
+            .expect("client init");
+        let mut request_stream = client
+            .send_request(Request::get("http://localhost/salut").body(()).unwrap())
+            .await
+            .expect("request");
+        request_stream.recv_response().await.expect("recv response");
+        request_stream.recv_data().await.expect("recv data");
+
+        let err_kind = request_stream.recv_trailers().await.unwrap_err().kind();
+        assert_matches!(
+            err_kind,
+            Kind::HeaderTooBig {
+                actual_size: 539,
+                max_size: 200,
+            }
+        );
+        request_stream.finish().await.expect("client finish");
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+
+        let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
+
+        // pretend server didn't receive settings
+        incoming_req
+            .state()
+            .0
+            .write()
+            .unwrap()
+            .peer_max_field_section_size = u64::MAX;
+
+        request_stream
+            .send_response(
+                Response::builder()
+                    .status(200)
+                    .body(())
+                    .expect("build response"),
+            )
+            .await
+            .expect("send_response");
+
+        request_stream
+            .send_data("wonderful hypertext".into())
+            .await
+            .expect("send_data");
+
+        let mut trailers = HeaderMap::new();
+        trailers.insert("trailer", "value".repeat(100).parse().unwrap());
+        request_stream
+            .send_trailers(trailers)
+            .await
+            .expect("send_trailers");
+        request_stream.finish().await.expect("finish");
+
+        let _ = incoming_req.accept().await;
+    };
+
+    tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn header_too_big_server_error() {
+    h3_tests::init_tracing();
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        let (_conn, mut client) = client::new(pair.client().await) // header size limit faked for brevity
+            .await
+            .expect("client init");
+
+        let req = Request::get("http://localhost/salut").body(()).unwrap();
+        let _ = client
+            .send_request(req)
+            .await
+            .unwrap()
+            .recv_response()
+            .await;
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        // pretend the server already received client's settings
+        incoming_req
+            .state()
+            .0
+            .write()
+            .unwrap()
+            .peer_max_field_section_size = 12;
+
+        let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
+        let err_kind = request_stream
+            .send_response(
+                Response::builder()
+                    .status(200)
+                    .body(())
+                    .expect("build response"),
+            )
+            .await
+            .map(|_| ())
+            .unwrap_err()
+            .kind();
+
+        assert_matches!(
+            err_kind,
+            Kind::HeaderTooBig {
+                actual_size: 42,
+                max_size: 12
+            }
+        );
+    };
+
+    tokio::join!(server_fut, client_fut);
+}
+
+#[tokio::test]
+async fn header_too_big_server_error_trailers() {
+    h3_tests::init_tracing();
+    let mut pair = Pair::new();
+    let mut server = pair.server();
+
+    let client_fut = async {
+        let (_conn, mut client) = client::new(pair.client().await) // header size limit faked for brevity
+            .await
+            .expect("client init");
+
+        let req = Request::get("http://localhost/salut").body(()).unwrap();
+        let _ = client
+            .send_request(req)
+            .await
+            .unwrap()
+            .recv_response()
+            .await;
+    };
+
+    let server_fut = async {
+        let conn = server.next().await;
+        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        // pretend the server already received client's settings
+        incoming_req
+            .state()
+            .0
+            .write()
+            .unwrap()
+            .peer_max_field_section_size = 200;
+
+        let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
+        request_stream
+            .send_response(
+                Response::builder()
+                    .status(200)
+                    .body(())
+                    .expect("build response"),
+            )
+            .await
+            .unwrap();
+        request_stream
+            .send_data("wonderful hypertext".into())
+            .await
+            .expect("send_data");
+
+        let mut trailers = HeaderMap::new();
+        trailers.insert("trailer", "value".repeat(100).parse().unwrap());
+        let err_kind = request_stream
+            .send_trailers(trailers)
+            .await
+            .unwrap_err()
+            .kind();
+        assert_matches!(
+            err_kind,
+            Kind::HeaderTooBig {
+                actual_size: 539,
+                max_size: 200,
+            }
+        );
     };
 
     tokio::join!(server_fut, client_fut);

--- a/tests/h3-tests/tests/request.rs
+++ b/tests/h3-tests/tests/request.rs
@@ -10,9 +10,7 @@ async fn get() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let mut client = client::Connection::new(pair.client().await)
-            .await
-            .expect("client init");
+        let (_, mut client) = client::new(pair.client().await).await.expect("client init");
         let mut request_stream = client
             .send_request(Request::get("http://localhost/salut").body(()).unwrap())
             .await
@@ -60,9 +58,7 @@ async fn get_with_trailers_unknown_content_type() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let mut client = client::Connection::new(pair.client().await)
-            .await
-            .expect("client init");
+        let (_, mut client) = client::new(pair.client().await).await.expect("client init");
         let mut request_stream = client
             .send_request(Request::get("http://localhost/salut").body(()).unwrap())
             .await
@@ -120,9 +116,7 @@ async fn get_with_trailers_known_content_type() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let mut client = client::Connection::new(pair.client().await)
-            .await
-            .expect("client init");
+        let (_, mut client) = client::new(pair.client().await).await.expect("client init");
         let mut request_stream = client
             .send_request(Request::get("http://localhost/salut").body(()).unwrap())
             .await
@@ -180,9 +174,7 @@ async fn post() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let mut client = client::Connection::new(pair.client().await)
-            .await
-            .expect("client init");
+        let (_, mut client) = client::new(pair.client().await).await.expect("client init");
         let mut request_stream = client
             .send_request(Request::get("http://localhost/salut").body(()).unwrap())
             .await


### PR DESCRIPTION
This PR enables uni-directionnal streams support.

It brings the "connection driving" shared state problem onto the table. This is why the two last commits are marked as DRAFTs. 
I took inspiration from h2 to manage Request streams (bi-directionnal) and connection-control stream (uni-directionnal). Dispatch them into tasks without lock / synchronization. 

On the server side, the "accept requests" task can be assumed to be continuously polled, which makes avoiding locks easy. But on the client side, to open new requests streams and poll for incoming recv streams, we need to share a mutable reference on the `Connection`.

@seanmonstar I recall you'd like to avoid using any locks in this crate, should I let `hyper` manage the concurrent accesses to the client Connection ?