### PR TITLE
Allow insecure client example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,15 +8,17 @@ edition = "2018"
 # [dependencies] instead.
 [dev-dependencies]
 futures = "0.3"
-http = "0.2"
 h3 = { path = "../h3" }
 h3-quinn = { path = "../h3-quinn" }
-tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1"
-tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }
-structopt = "0.3"
+http = "0.2"
 rcgen = { version = "0.7.0" }
+rustls = { version = "0.19", features = ["dangerous_configuration"] }
+structopt = "0.3"
+tokio-stream = "0.1"
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1.10"
+tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }
+webpki = "0.21"
 
 [[example]]
 name = "client"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tls_config.enable_early_data = true;
         tls_config
             .dangerous()
-            .set_certificate_verifier(Arc::new(YesVerifier(Arc::new(Mutex::new(())))));
+            .set_certificate_verifier(Arc::new(YesVerifier));
         tls_config.alpn_protocols = vec![ALPN.into()];
 
         let transport = quinn::TransportConfig::default();
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-struct YesVerifier(Arc<Mutex<()>>);
+struct YesVerifier;
 impl rustls::ServerCertVerifier for YesVerifier {
     fn verify_server_cert(
         &self,

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,4 +1,22 @@
+use std::sync::{Arc, Mutex};
+
+use h3_quinn::quinn;
+use rustls;
+use structopt::StructOpt;
 use tokio::io::AsyncWriteExt;
+use webpki;
+
+static ALPN: &[u8] = b"h3-29";
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "server")]
+struct Opt {
+    #[structopt(long)]
+    pub insecure: bool,
+
+    #[structopt()]
+    pub uri: String,
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -8,11 +26,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_writer(std::io::stderr)
         .init();
 
-    let dest = std::env::args()
-        .nth(1)
-        .ok_or("must include destination argument")?;
+    let opt = Opt::from_args();
 
-    let dest = dest.parse::<http::Uri>()?;
+    let dest = opt.uri.parse::<http::Uri>()?;
 
     if dest.scheme() != Some(&http::uri::Scheme::HTTPS) {
         Err("destination scheme must be 'https'")?;
@@ -35,10 +51,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // quinn setup
     let mut client_config = h3_quinn::quinn::ClientConfigBuilder::default();
-    client_config.protocols(&[b"h3-29"]);
+    client_config.protocols(&[ALPN]);
 
     let mut client_endpoint_builder = h3_quinn::quinn::Endpoint::builder();
-    client_endpoint_builder.default_client_config(client_config.build());
+
+    if !opt.insecure {
+        client_endpoint_builder.default_client_config(client_config.build());
+    } else {
+        let mut tls_config = rustls::ClientConfig::new();
+        tls_config.versions = vec![rustls::ProtocolVersion::TLSv1_3];
+        tls_config.enable_early_data = true;
+        tls_config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(YesVerifier(Arc::new(Mutex::new(())))));
+        tls_config.alpn_protocols = vec![ALPN.into()];
+
+        let transport = quinn::TransportConfig::default();
+        client_endpoint_builder.default_client_config(quinn::ClientConfig {
+            crypto: Arc::new(tls_config),
+            transport: Arc::new(transport),
+        });
+    }
+
     let (client_endpoint, _) = client_endpoint_builder
         .bind(&"[::]:0".parse().unwrap())
         .unwrap();
@@ -73,4 +107,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+struct YesVerifier(Arc<Mutex<()>>);
+impl rustls::ServerCertVerifier for YesVerifier {
+    fn verify_server_cert(
+        &self,
+        _roots: &rustls::RootCertStore,
+        _presented_certs: &[rustls::Certificate],
+        _dns_name: webpki::DNSNameRef,
+        _ocsp_response: &[u8],
+    ) -> std::result::Result<rustls::ServerCertVerified, rustls::TLSError> {
+        Ok(rustls::ServerCertVerified::assertion())
+    }
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // quinn setup
     let mut server_config = h3_quinn::quinn::ServerConfigBuilder::default();
-    server_config.protocols(&[b"h3-27"]);
+    server_config.protocols(&[b"h3-29"]);
 
     let (endpoint, mut incoming) = match opt.command {
         Command::SelfSigned(r) => {


### PR DESCRIPTION
fix #51 by adding an `--insecure` flag to the client example.