### PR TITLE
Hide `FrameStream` from public API

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,33 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  build:
+    name: Build
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+          - "1.50"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install Rust (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p h3
+
   test:
     name: Test ${{ matrix.rust }}
     needs: [style]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -115,10 +115,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         while let Some(chunk) = stream.recv_data().await? {
             let mut out = tokio::io::stdout();
-            out.write_all(&chunk).await?;
-            out.flush().await?;
+            out.write_all(&chunk).await.expect("write_all");
+            out.flush().await.expect("flush");
         }
-        Ok::<(), Box<dyn std::error::Error>>(())
+        Ok::<_, Box<dyn std::error::Error>>(())
     };
 
     tokio::select! {

--- a/h3/src/error.rs
+++ b/h3/src/error.rs
@@ -221,6 +221,11 @@ impl Error {
         false
     }
 
+    #[cfg(not(feature = "test_helpers"))]
+    pub(crate) fn kind(&self) -> Kind {
+        self.inner.kind.clone()
+    }
+
     #[cfg(feature = "test_helpers")]
     pub fn kind(&self) -> Kind {
         self.inner.kind.clone()

--- a/h3/src/error.rs
+++ b/h3/src/error.rs
@@ -350,6 +350,12 @@ impl From<frame::Error> for Error {
     }
 }
 
+impl From<Error> for Box<dyn std::error::Error + std::marker::Send> {
+    fn from(e: Error) -> Self {
+        Box::new(e)
+    }
+}
+
 impl<T> From<T> for Error
 where
     T: Into<TransportError>,


### PR DESCRIPTION
As dicussed in #56 and #57, wrap the `RequestStream` impls to remove the need of importing `FrameStream` to name the type. I used `Deref` and `DerefMut` to make all the methods transparently callable in downstream code. I wonder how recommendable is that technique?

I also updated the examples to show how to pass `RequestStream`s as argument, including the boundaries to use.