### PR TITLE
Restore timeout tests and fix client driver result on NO_ERROR closure

### DIFF
--- a/tests/h3-tests/tests/connection.rs
+++ b/tests/h3-tests/tests/connection.rs
@@ -391,10 +391,11 @@ async fn control_stream_frame_unexpected() {
 async fn timeout_on_control_frame_read() {
     h3_tests::init_tracing();
     let mut pair = Pair::new();
+    pair.with_timeout(Duration::from_millis(10));
+
     let mut server = pair.server();
 
     let client_fut = async {
-        pair.with_timeout(Duration::from_millis(1));
         let (mut driver, _send_request) = client::new(pair.client().await).await.unwrap();
         let _ = future::poll_fn(|cx| driver.poll_close(cx)).await;
     };

--- a/tests/h3-tests/tests/request.rs
+++ b/tests/h3-tests/tests/request.rs
@@ -773,14 +773,12 @@ async fn get_timeout_client_recv_response() {
                 .expect("request");
 
             let response = request_stream.recv_response().await;
-            // TODO should be Kind::Timeout
-            assert_matches!(response.unwrap_err().kind(), h3::error::Kind::Closed);
+            assert_matches!(response.unwrap_err().kind(), h3::error::Kind::Timeout);
         };
 
         let drive_fut = async move {
             let result = future::poll_fn(|cx| conn.poll_close(cx)).await;
-            // TODO should be Kind::Timeout
-            assert_matches!(result.unwrap_err().kind(), h3::error::Kind::Closed);
+            assert_matches!(result.unwrap_err().kind(), h3::error::Kind::Timeout);
         };
 
         tokio::join!(drive_fut, request_fut);
@@ -816,14 +814,12 @@ async fn get_timeout_client_recv_data() {
 
             let _ = request_stream.recv_response().await.unwrap();
             let data = request_stream.recv_data().await;
-            // TODO should be Kind::Timeout
-            assert_matches!(data.unwrap_err().kind(), h3::error::Kind::Closed);
+            assert_matches!(data.unwrap_err().kind(), h3::error::Kind::Timeout);
         };
 
         let drive_fut = async move {
             let result = future::poll_fn(|cx| conn.poll_close(cx)).await;
-            // TODO should be Kind::Timeout
-            assert_matches!(result.unwrap_err().kind(), h3::error::Kind::Closed);
+            assert_matches!(result.unwrap_err().kind(), h3::error::Kind::Timeout);
         };
 
         tokio::join!(drive_fut, request_fut);
@@ -904,10 +900,9 @@ async fn post_timeout_server_recv_data() {
         let mut incoming_req = server::Connection::new(conn).await.unwrap();
 
         let (_, mut req_stream) = incoming_req.accept().await.expect("accept").unwrap();
-        // TODO should be Kind::Timeout
         assert_matches!(
             req_stream.recv_data().await.unwrap_err().kind(),
-            h3::error::Kind::Closed
+            h3::error::Kind::Timeout
         );
     };
 


### PR DESCRIPTION
1. Make the example run without printing errors when there are none:
-  Wait for the `quinn` endpoint to send CONNECTION_CLOSE frame.
- Catch errors that are the consequence of a previous connection error in client driver
- Make the driver return Ok(()) when connection is closed with  NO_ERROR.
- Wake the connection driver up when and `SendRequest`s are dropped.

2. Restore the timeout-related tests.