### PR TITLE
Make body data types generic

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use futures::{future, FutureExt};
+use futures::future;
 use h3_quinn::quinn;
 use rustls::{self, client::ServerCertVerified};
 use rustls::{Certificate, ServerName};

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -118,9 +118,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("Response: {:?} {}", resp.version(), resp.status());
         eprintln!("Headers: {:#?}", resp.headers());
 
-        while let Some(chunk) = stream.recv_data().await? {
+        while let Some(mut chunk) = stream.recv_data().await? {
             let mut out = tokio::io::stdout();
-            out.write_all(&chunk).await.expect("write_all");
+            out.write_all_buf(&mut chunk).await.expect("write_all");
             out.flush().await.expect("flush");
         }
         Ok::<_, Box<dyn std::error::Error>>(())

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -129,7 +129,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn handle_request<T>(
-    mut stream: RequestStream<T>,
+    mut stream: RequestStream<T, Bytes>,
 ) -> Result<(), Box<dyn std::error::Error + Send>>
 where
     T: BidiStream<Bytes>,

--- a/h3/Cargo.toml
+++ b/h3/Cargo.toml
@@ -16,5 +16,5 @@ http = "0.2.3"
 
 [dev-dependencies]
 assert_matches= "1.3.0"
-tokio = "1"
+tokio = { version = "1", features = ["rt", "macros"] }
 proptest = "0.10.1"

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -1,4 +1,4 @@
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use futures::future;
 use http::{request, HeaderMap, Response};
 use std::{
@@ -288,7 +288,7 @@ where
         Ok(resp)
     }
 
-    pub async fn recv_data(&mut self) -> Result<Option<Bytes>, Error> {
+    pub async fn recv_data(&mut self) -> Result<Option<impl Buf>, Error> {
         self.inner.recv_data().await
     }
 

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -295,7 +295,7 @@ where
     pub async fn recv_trailers(&mut self) -> Result<Option<HeaderMap>, Error> {
         let res = self.inner.recv_trailers().await;
         if let Err(ref e) = res {
-            if let crate::error::Kind::HeaderTooBig { .. } = e.kind() {
+            if e.is_header_too_big() {
                 self.inner.stream.stop_sending(Code::H3_REQUEST_CANCELLED);
             }
         }

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -5,7 +5,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use futures::{future, ready};
 use http::HeaderMap;
 
@@ -257,7 +257,7 @@ where
     S: quic::RecvStream,
 {
     /// Receive some of the request body.
-    pub async fn recv_data(&mut self) -> Result<Option<Bytes>, Error> {
+    pub async fn recv_data(&mut self) -> Result<Option<impl Buf>, Error> {
         if !self.stream.has_data() {
             let frame = future::poll_fn(|cx| self.stream.poll_next(cx))
                 .await

--- a/h3/src/error.rs
+++ b/h3/src/error.rs
@@ -221,9 +221,8 @@ impl Error {
         false
     }
 
-    #[cfg(not(feature = "test_helpers"))]
-    pub(crate) fn kind(&self) -> Kind {
-        self.inner.kind.clone()
+    pub(crate) fn is_header_too_big(&self) -> bool {
+        matches!(&self.inner.kind, Kind::HeaderTooBig { .. })
     }
 
     #[cfg(feature = "test_helpers")]

--- a/h3/src/proto/frame.rs
+++ b/h3/src/proto/frame.rs
@@ -94,7 +94,7 @@ impl Frame<PayloadLen> {
         };
         if let Ok(frame) = &frame {
             trace!(
-                "got frame {}, len: {}, remaining: {}",
+                "got frame {:?}, len: {}, remaining: {}",
                 frame,
                 len,
                 buf.remaining()
@@ -170,34 +170,10 @@ where
     }
 }
 
-impl fmt::Display for Frame<PayloadLen> {
+impl fmt::Debug for Frame<PayloadLen> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Frame::Data(len) => write!(f, "Data: {} bytes", len.0),
-            Frame::Headers(frame) => write!(f, "Headers({} entries)", frame.len()),
-            Frame::Settings(_) => write!(f, "Settings"),
-            Frame::CancelPush(id) => write!(f, "CancelPush({})", id),
-            Frame::PushPromise(frame) => write!(f, "PushPromise({})", frame.id),
-            Frame::Goaway(id) => write!(f, "GoAway({})", id),
-            Frame::MaxPushId(id) => write!(f, "MaxPushId({})", id),
-            Frame::DuplicatePush(id) => write!(f, "DuplicatePush({})", id),
-        }
-    }
-}
-
-impl fmt::Debug for Frame<PayloadLen> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        <Self as fmt::Display>::fmt(self, f)
-    }
-}
-
-impl<B> fmt::Display for Frame<B>
-where
-    B: Buf,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Frame::Data(data) => write!(f, "Data: {} bytes", data.remaining()),
             Frame::Headers(frame) => write!(f, "Headers({} entries)", frame.len()),
             Frame::Settings(_) => write!(f, "Settings"),
             Frame::CancelPush(id) => write!(f, "CancelPush({})", id),
@@ -214,7 +190,16 @@ where
     B: Buf,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        <Self as fmt::Display>::fmt(self, f)
+        match self {
+            Frame::Data(data) => write!(f, "Data: {} bytes", data.remaining()),
+            Frame::Headers(frame) => write!(f, "Headers({} entries)", frame.len()),
+            Frame::Settings(_) => write!(f, "Settings"),
+            Frame::CancelPush(id) => write!(f, "CancelPush({})", id),
+            Frame::PushPromise(frame) => write!(f, "PushPromise({})", frame.id),
+            Frame::Goaway(id) => write!(f, "GoAway({})", id),
+            Frame::MaxPushId(id) => write!(f, "MaxPushId({})", id),
+            Frame::DuplicatePush(id) => write!(f, "DuplicatePush({})", id),
+        }
     }
 }
 

--- a/h3/src/proto/stream.rs
+++ b/h3/src/proto/stream.rs
@@ -1,7 +1,10 @@
 use bytes::{Buf, BufMut};
 use std::fmt;
 
-use super::coding::{BufExt, BufMutExt, Decode, Encode, UnexpectedEnd};
+use super::{
+    coding::{BufExt, BufMutExt, Decode, Encode, UnexpectedEnd},
+    varint::VarInt,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct StreamType(u64);
@@ -22,6 +25,8 @@ stream_types! {
 }
 
 impl StreamType {
+    pub const MAX_ENCODED_SIZE: usize = VarInt::MAX_SIZE;
+
     pub fn value(&self) -> u64 {
         self.0
     }

--- a/h3/src/quic.rs
+++ b/h3/src/quic.rs
@@ -7,6 +7,8 @@ use std::task::{self, Poll};
 
 use bytes::Buf;
 
+pub use crate::stream::WriteBuf;
+
 // Unresolved questions:
 //
 // - Should the `poll_` methods be `Pin<&mut Self>`?
@@ -110,7 +112,7 @@ pub trait SendStream<B: Buf> {
     fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>>;
 
     /// Send more data on the stream.
-    fn send_data(&mut self, data: B) -> Result<(), Self::Error>;
+    fn send_data<T: Into<WriteBuf<B>>>(&mut self, data: T) -> Result<(), Self::Error>;
 
     /// Poll to finish the sending side of the stream.
     fn poll_finish(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>>;

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -1,4 +1,4 @@
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use futures::future;
 use http::{response, HeaderMap, Request, Response, StatusCode};
 use std::{
@@ -206,7 +206,7 @@ impl<S> RequestStream<S>
 where
     S: quic::RecvStream,
 {
-    pub async fn recv_data(&mut self) -> Result<Option<Bytes>, Error> {
+    pub async fn recv_data(&mut self) -> Result<Option<impl Buf>, Error> {
         self.inner.recv_data().await
     }
 

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -265,7 +265,7 @@ where
     pub async fn recv_trailers(&mut self) -> Result<Option<HeaderMap>, Error> {
         let res = self.inner.recv_trailers().await;
         if let Err(ref e) = res {
-            if let error::Kind::HeaderTooBig { .. } = e.kind() {
+            if e.is_header_too_big() {
                 self.send_response(
                     http::Response::builder()
                         .status(StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE)

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -49,7 +49,7 @@ where
     stream: S,
     ty: Option<StreamType>,
     push_id: Option<u64>,
-    buf: BufList<S::Buf>,
+    buf: BufList<Bytes>,
     expected: Option<usize>,
 }
 
@@ -95,7 +95,7 @@ where
             }
 
             match ready!(self.stream.poll_data(cx))? {
-                Some(b) => self.buf.push(b),
+                Some(mut b) => self.buf.push_bytes(&mut b),
                 None => {
                     return Poll::Ready(Err(Code::H3_STREAM_CREATION_ERROR
                         .with_reason("Stream closed before type received")))

--- a/tests/h3-tests/src/lib.rs
+++ b/tests/h3-tests/src/lib.rs
@@ -1,11 +1,6 @@
-use std::{
-    convert::TryInto,
-    net::{Ipv6Addr, ToSocketAddrs},
-    sync::Arc,
-    time::Duration,
-};
+use std::{convert::TryInto, net::{Ipv6Addr, ToSocketAddrs}, sync::Arc, task::Poll, time::Duration};
 
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use futures::StreamExt;
 use rustls::{Certificate, PrivateKey};
 
@@ -124,4 +119,10 @@ pub fn build_certs() -> (Certificate, PrivateKey) {
     let key = PrivateKey(cert.serialize_private_key_der());
     let cert = Certificate(cert.serialize_der().unwrap());
     (cert, key)
+}
+
+pub fn to_bytes<E>(
+    x: Poll<Result<Option<impl Buf>, E>>,
+) -> Poll<Result<Option<Bytes>, E>> {
+    x.map(|b| b.map(|b| b.map(|mut b| b.copy_to_bytes(b.remaining()))))
 }

--- a/tests/h3-tests/src/lib.rs
+++ b/tests/h3-tests/src/lib.rs
@@ -1,4 +1,10 @@
-use std::{convert::TryInto, net::{Ipv6Addr, ToSocketAddrs}, sync::Arc, task::Poll, time::Duration};
+use std::{
+    convert::TryInto,
+    net::{Ipv6Addr, ToSocketAddrs},
+    sync::Arc,
+    task::Poll,
+    time::Duration,
+};
 
 use bytes::{Buf, Bytes};
 use futures::StreamExt;
@@ -121,8 +127,6 @@ pub fn build_certs() -> (Certificate, PrivateKey) {
     (cert, key)
 }
 
-pub fn to_bytes<E>(
-    x: Poll<Result<Option<impl Buf>, E>>,
-) -> Poll<Result<Option<Bytes>, E>> {
+pub fn to_bytes<E>(x: Poll<Result<Option<impl Buf>, E>>) -> Poll<Result<Option<Bytes>, E>> {
     x.map(|b| b.map(|b| b.map(|mut b| b.copy_to_bytes(b.remaining()))))
 }


### PR DESCRIPTION
Get closer to the original design proposal by making the API generic over send and receive `Buf` data types.

