### PR TITLE
Graceful shutdown implementation

### DIFF
--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -15,7 +15,7 @@ pub use quinn::{
     VarInt, WriteError,
 };
 
-use h3::quic::{self, Error, WriteBuf};
+use h3::quic::{self, Error, StreamId, WriteBuf};
 
 pub struct Connection {
     conn: quinn::Connection,
@@ -276,7 +276,7 @@ where
         self.send.send_data(data)
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> StreamId {
         self.send.id()
     }
 }
@@ -424,8 +424,8 @@ where
         Ok(())
     }
 
-    fn id(&self) -> u64 {
-        self.stream.id().0
+    fn id(&self) -> StreamId {
+        self.stream.id().0.into()
     }
 }
 

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This module implements QUIC traits with Quinn.
 use std::{
+    convert::TryInto,
     fmt::{self, Display},
     pin::Pin,
     sync::Arc,
@@ -426,7 +427,7 @@ where
     }
 
     fn id(&self) -> StreamId {
-        self.stream.id().0.into()
+        self.stream.id().0.try_into().expect("invalid stream id")
     }
 }
 

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -349,6 +349,7 @@ impl Error for ReadError {
             quinn::ReadError::ConnectionLost(quinn::ConnectionError::ApplicationClosed(
                 quinn_proto::ApplicationClose { error_code, .. },
             )) => Some(error_code.into_inner()),
+            quinn::ReadError::Reset(error_code) => Some(error_code.into_inner()),
             _ => None,
         }
     }

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -11,8 +11,8 @@ use std::{
 use bytes::{Buf, Bytes};
 use futures::{ready, AsyncWrite as _, FutureExt as _, StreamExt as _};
 pub use quinn::{
-    self, crypto::Session, IncomingBiStreams, IncomingUniStreams, NewConnection, OpenBi, OpenUni,
-    VarInt, WriteError,
+    self, crypto::Session, Endpoint, IncomingBiStreams, IncomingUniStreams, NewConnection, OpenBi,
+    OpenUni, VarInt, WriteError,
 };
 
 use h3::quic::{self, Error, StreamId, WriteBuf};

--- a/h3/Cargo.toml
+++ b/h3/Cargo.toml
@@ -11,8 +11,9 @@ test_helpers = []
 [dependencies]
 bytes = "1"
 futures = "0.3"
-tracing = "0.1.18"
 http = "0.2.3"
+tokio = { version = "1", features = ["sync"] }
+tracing = "0.1.18"
 
 [dev-dependencies]
 assert_matches= "1.3.0"

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -158,6 +158,10 @@ where
     C: quic::Connection<B>,
     B: Buf,
 {
+    pub async fn shutdown(&mut self, max_requests: usize) -> Result<(), Error> {
+        self.inner.shutdown(max_requests).await
+    }
+
     pub fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
         while let Poll::Ready(result) = self.inner.poll_control(cx) {
             match result {

--- a/h3/src/error.rs
+++ b/h3/src/error.rs
@@ -347,6 +347,7 @@ impl From<frame::Error> for Error {
                 Code::H3_FRAME_ERROR.with_reason("received incomplete frame")
             }
             frame::Error::Proto(e) => match e {
+                proto::frame::Error::InvalidStreamId(_) => Code::H3_ID_ERROR,
                 proto::frame::Error::Settings(_) => Code::H3_SETTINGS_ERROR,
                 proto::frame::Error::UnsupportedFrame(_) | proto::frame::Error::UnknownFrame(_) => {
                     Code::H3_FRAME_UNEXPECTED
@@ -384,6 +385,12 @@ where
             }),
             None => Error::new(Kind::Transport(Arc::new(quic_error))),
         }
+    }
+}
+
+impl From<proto::stream::InvalidStreamId> for Error {
+    fn from(e: proto::stream::InvalidStreamId) -> Self {
+        Self::from(Code::H3_ID_ERROR).with_cause(format!("{}", e))
     }
 }
 

--- a/h3/src/frame.rs
+++ b/h3/src/frame.rs
@@ -8,7 +8,10 @@ use tracing::trace;
 use crate::{
     buf::BufList,
     error::TransportError,
-    proto::frame::{self, Frame, PayloadLen},
+    proto::{
+        frame::{self, Frame, PayloadLen},
+        stream::StreamId,
+    },
     quic::{RecvStream, SendStream},
     stream::WriteBuf,
 };
@@ -154,7 +157,7 @@ where
         self.stream.reset(reset_code)
     }
 
-    fn id(&self) -> u64 {
+    fn id(&self) -> StreamId {
         self.stream.id()
     }
 }

--- a/h3/src/proto/frame.rs
+++ b/h3/src/proto/frame.rs
@@ -41,7 +41,6 @@ pub enum Frame<B> {
     PushPromise(PushPromise),
     Goaway(u64),
     MaxPushId(u64),
-    DuplicatePush(u64),
 }
 
 /// Represents the available data len for a `Data` frame on a RecvStream
@@ -82,7 +81,6 @@ impl Frame<PayloadLen> {
             FrameType::PUSH_PROMISE => Ok(Frame::PushPromise(PushPromise::decode(&mut payload)?)),
             FrameType::GOAWAY => Ok(Frame::Goaway(payload.get_var()?)),
             FrameType::MAX_PUSH_ID => Ok(Frame::MaxPushId(payload.get_var()?)),
-            FrameType::DUPLICATE_PUSH => Ok(Frame::DuplicatePush(payload.get_var()?)),
             FrameType::H2_PRIORITY
             | FrameType::H2_PING
             | FrameType::H2_WINDOW_UPDATE
@@ -123,7 +121,6 @@ where
             Frame::CancelPush(id) => simple_frame_encode(FrameType::CANCEL_PUSH, *id, buf),
             Frame::Goaway(id) => simple_frame_encode(FrameType::GOAWAY, *id, buf),
             Frame::MaxPushId(id) => simple_frame_encode(FrameType::MAX_PUSH_ID, *id, buf),
-            Frame::DuplicatePush(id) => simple_frame_encode(FrameType::DUPLICATE_PUSH, *id, buf),
         }
     }
 }
@@ -180,7 +177,6 @@ impl fmt::Debug for Frame<PayloadLen> {
             Frame::PushPromise(frame) => write!(f, "PushPromise({})", frame.id),
             Frame::Goaway(id) => write!(f, "GoAway({})", id),
             Frame::MaxPushId(id) => write!(f, "MaxPushId({})", id),
-            Frame::DuplicatePush(id) => write!(f, "DuplicatePush({})", id),
         }
     }
 }
@@ -198,7 +194,6 @@ where
             Frame::PushPromise(frame) => write!(f, "PushPromise({})", frame.id),
             Frame::Goaway(id) => write!(f, "GoAway({})", id),
             Frame::MaxPushId(id) => write!(f, "MaxPushId({})", id),
-            Frame::DuplicatePush(id) => write!(f, "DuplicatePush({})", id),
         }
     }
 }
@@ -217,7 +212,6 @@ impl<T, U> PartialEq<Frame<T>> for Frame<U> {
             Frame::PushPromise(x) => matches!(other, Frame::PushPromise(y) if x == y),
             Frame::Goaway(x) => matches!(other, Frame::Goaway(y) if x == y),
             Frame::MaxPushId(x) => matches!(other, Frame::MaxPushId(y) if x == y),
-            Frame::DuplicatePush(x) => matches!(other, Frame::DuplicatePush(y) if x == y),
         }
     }
 }
@@ -249,7 +243,6 @@ frame_types! {
     H2_WINDOW_UPDATE = 0x8,
     H2_CONTINUATION = 0x9,
     MAX_PUSH_ID = 0xD,
-    DUPLICATE_PUSH = 0xE,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -558,7 +551,6 @@ mod tests {
         codec_frame_check(Frame::CancelPush(2), &[3, 1, 2]);
         codec_frame_check(Frame::Goaway(2), &[7, 1, 2]);
         codec_frame_check(Frame::MaxPushId(2), &[13, 1, 2]);
-        codec_frame_check(Frame::DuplicatePush(2), &[14, 1, 2]);
     }
 
     #[test]

--- a/h3/src/proto/stream.rs
+++ b/h3/src/proto/stream.rs
@@ -1,5 +1,9 @@
 use bytes::{Buf, BufMut};
-use std::{fmt, ops::Add};
+use std::{
+    convert::TryFrom,
+    fmt::{self, Display},
+    ops::Add,
+};
 
 use super::{
     coding::{BufExt, BufMutExt, Decode, Encode, UnexpectedEnd},
@@ -124,9 +128,22 @@ impl StreamId {
     }
 }
 
-impl From<u64> for StreamId {
-    fn from(v: u64) -> Self {
-        Self(v)
+impl TryFrom<u64> for StreamId {
+    type Error = InvalidStreamId;
+    fn try_from(v: u64) -> Result<Self, Self::Error> {
+        if v > VarInt::MAX.0 {
+            return Err(InvalidStreamId(v));
+        }
+        Ok(Self(v))
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct InvalidStreamId(u64);
+
+impl Display for InvalidStreamId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid stream id: {:x}", self.0)
     }
 }
 

--- a/h3/src/proto/stream.rs
+++ b/h3/src/proto/stream.rs
@@ -54,3 +54,92 @@ impl fmt::Display for StreamType {
         }
     }
 }
+
+/// Identifier for a stream
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct StreamId(
+    #[cfg(not(any(test, feature = "test_helpers")))] u64,
+    #[cfg(any(test, feature = "test_helpers"))] pub u64,
+);
+
+impl fmt::Display for StreamId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let initiator = match self.initiator() {
+            Side::Client => "client",
+            Side::Server => "server",
+        };
+        let dir = match self.dir() {
+            Dir::Uni => "uni",
+            Dir::Bi => "bi",
+        };
+        write!(
+            f,
+            "{} {}directional stream {}",
+            initiator,
+            dir,
+            self.index()
+        )
+    }
+}
+
+impl StreamId {
+    /// Distinguishes streams of the same initiator and directionality
+    pub fn index(self) -> u64 {
+        self.0 >> 2
+    }
+
+    pub fn is_request(&self) -> bool {
+        self.dir() == Dir::Bi && self.initiator() == Side::Client
+    }
+
+    pub fn is_push(&self) -> bool {
+        self.dir() == Dir::Uni && self.initiator() == Side::Server
+    }
+
+    /// Create a new StreamId
+    /// Which side of a connection initiated the stream
+    fn initiator(self) -> Side {
+        if self.0 & 0x1 == 0 {
+            Side::Client
+        } else {
+            Side::Server
+        }
+    }
+    /// Which directions data flows in
+    fn dir(self) -> Dir {
+        if self.0 & 0x2 == 0 {
+            Dir::Bi
+        } else {
+            Dir::Uni
+        }
+    }
+}
+
+impl From<u64> for StreamId {
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl Encode for StreamId {
+    fn encode<B: bytes::BufMut>(&self, buf: &mut B) {
+        VarInt::from_u64(self.0).unwrap().encode(buf);
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum Side {
+    /// The initiator of a connection
+    Client = 0,
+    /// The acceptor of a connection
+    Server = 1,
+}
+
+/// Whether a stream communicates data in both directions or only from the initiator
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum Dir {
+    /// Data flows in both directions
+    Bi = 0,
+    /// Data flows only from the stream's initiator
+    Uni = 1,
+}

--- a/h3/src/quic.rs
+++ b/h3/src/quic.rs
@@ -7,7 +7,7 @@ use std::task::{self, Poll};
 
 use bytes::Buf;
 
-pub use crate::proto::stream::StreamId;
+pub use crate::proto::stream::{InvalidStreamId, StreamId};
 pub use crate::stream::WriteBuf;
 
 // Unresolved questions:

--- a/h3/src/quic.rs
+++ b/h3/src/quic.rs
@@ -7,6 +7,7 @@ use std::task::{self, Poll};
 
 use bytes::Buf;
 
+pub use crate::proto::stream::StreamId;
 pub use crate::stream::WriteBuf;
 
 // Unresolved questions:
@@ -121,7 +122,7 @@ pub trait SendStream<B: Buf> {
     fn reset(&mut self, reset_code: u64);
 
     /// Get QUIC send stream id
-    fn id(&self) -> u64;
+    fn id(&self) -> StreamId;
 }
 
 /// A trait describing the "receive" actions of a QUIC stream.

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -262,6 +262,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::proto::stream::StreamId;
 
     #[test]
     fn write_buf_encode_streamtype() {
@@ -273,7 +274,7 @@ mod tests {
 
     #[test]
     fn write_buf_encode_frame() {
-        let wbuf = WriteBuf::<Bytes>::from(Frame::Goaway(2));
+        let wbuf = WriteBuf::<Bytes>::from(Frame::Goaway(StreamId(2)));
 
         assert_eq!(wbuf.chunk(), b"\x07\x01\x02");
         assert_eq!(wbuf.len, 3);
@@ -281,7 +282,7 @@ mod tests {
 
     #[test]
     fn write_buf_encode_streamtype_then_frame() {
-        let wbuf = WriteBuf::<Bytes>::from((StreamType::ENCODER, Frame::Goaway(2)));
+        let wbuf = WriteBuf::<Bytes>::from((StreamType::ENCODER, Frame::Goaway(StreamId(2))));
 
         assert_eq!(wbuf.chunk(), b"\x02\x07\x01\x02");
     }

--- a/tests/h3-tests/src/lib.rs
+++ b/tests/h3-tests/src/lib.rs
@@ -54,7 +54,7 @@ impl Pair {
             .initial_rtt(Duration::from_millis(10));
     }
 
-    pub fn server(&mut self) -> Server {
+    pub fn server_inner(&mut self) -> Incoming {
         let mut crypto = rustls::ServerConfig::builder()
             .with_safe_default_cipher_suites()
             .with_safe_default_kx_groups()
@@ -73,7 +73,13 @@ impl Pair {
 
         self.port = endpoint.local_addr().unwrap().port();
 
-        Server { incoming }
+        incoming
+    }
+
+    pub fn server(&mut self) -> Server {
+        Server {
+            incoming: self.server_inner(),
+        }
     }
 
     pub async fn client_inner(&self) -> NewConnection {

--- a/tests/h3-tests/src/lib.rs
+++ b/tests/h3-tests/src/lib.rs
@@ -54,7 +54,7 @@ impl Pair {
             .initial_rtt(Duration::from_millis(10));
     }
 
-    pub fn server_inner(&mut self) -> Incoming {
+    pub fn server_inner(&mut self) -> (h3_quinn::Endpoint, Incoming) {
         let mut crypto = rustls::ServerConfig::builder()
             .with_safe_default_cipher_suites()
             .with_safe_default_kx_groups()
@@ -73,13 +73,12 @@ impl Pair {
 
         self.port = endpoint.local_addr().unwrap().port();
 
-        incoming
+        (endpoint, incoming)
     }
 
     pub fn server(&mut self) -> Server {
-        Server {
-            incoming: self.server_inner(),
-        }
+        let (endpoint, incoming) = self.server_inner();
+        Server { endpoint, incoming }
     }
 
     pub async fn client_inner(&self) -> NewConnection {
@@ -119,6 +118,7 @@ impl Pair {
 }
 
 pub struct Server {
+    pub endpoint: h3_quinn::Endpoint,
     pub incoming: Incoming,
 }
 

--- a/tests/h3-tests/tests/request.rs
+++ b/tests/h3-tests/tests/request.rs
@@ -1098,7 +1098,6 @@ fn invalid_request_frames() -> Vec<Frame<Bytes>> {
         Frame::Settings(frame::Settings::default()),
         Frame::Goaway(1),
         Frame::MaxPushId(1),
-        Frame::DuplicatePush(1),
     ]
 }
 

--- a/tests/h3-tests/tests/request.rs
+++ b/tests/h3-tests/tests/request.rs
@@ -15,6 +15,7 @@ use h3::{
             coding::Encode,
             frame::{self, Frame, FrameType},
             headers::Header,
+            stream::StreamId,
             varint::VarInt,
         },
         qpack, ConnectionState,
@@ -1094,10 +1095,10 @@ async fn request_valid_unkown_frame_after_trailers() {
 // Receipt of an invalid sequence of frames MUST be treated as a connection error of type H3_FRAME_UNEXPECTED
 fn invalid_request_frames() -> Vec<Frame<Bytes>> {
     vec![
-        Frame::CancelPush(0),
+        Frame::CancelPush(StreamId(0)),
         Frame::Settings(frame::Settings::default()),
-        Frame::Goaway(1),
-        Frame::MaxPushId(1),
+        Frame::Goaway(StreamId(1)),
+        Frame::MaxPushId(StreamId(1)),
     ]
 }
 


### PR DESCRIPTION
Sends `GO_AWAY` frames and tracks ongoing requests in server. Then make `accept()` return `Ok(None)` when all requests have completed, so the user will definitively close by dropping `Connection`.

Adresses #65. Based on #67 and #68.