### PR TITLE
quinn main update using async traits

### DIFF
--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 h3 = { path = "../h3" }
 bytes = "1"
-quinn = "0.8.0"
-quinn-proto = "0.8.0"
+quinn = { git = "https://www.github.com/quinn-rs/quinn", branch = "main" }
+quinn-proto = { git = "https://www.github.com/quinn-rs/quinn", branch = "main" }
 futures = "0.3"
 
 [dev-dependencies]

--- a/h3/Cargo.toml
+++ b/h3/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.3"
 http = "0.2.3"
 tokio = { version = "1", features = ["sync"] }
 tracing = "0.1.18"
+async-trait = "0.1.52"
 
 [dev-dependencies]
 assert_matches= "1.3.0"


### PR DESCRIPTION
Quinn has removed the Open* Future structs that h3 was storing for polling. I tried storing it myself, but the lifetimes got very complicated. Then I tried using async traits and removing polling but got stuck again with lifetimes. I'll share my work in case this is the path you want to go down for keeping up to date with quinn, but in any case a breakage is coming with 0.9.0.