### PR TITLE
recv_data always returns Bytes

### DIFF
--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -337,7 +337,7 @@ where
     S: quic::RecvStream,
 {
     /// Receive some of the request body.
-    pub async fn recv_data(&mut self) -> Result<Option<impl Buf>, Error> {
+    pub async fn recv_data(&mut self) -> Result<Option<Bytes>, Error> {
         if !self.stream.has_data() {
             let frame = future::poll_fn(|cx| self.stream.poll_next(cx))
                 .await

--- a/h3/src/frame.rs
+++ b/h3/src/frame.rs
@@ -82,7 +82,7 @@ where
         }
     }
 
-    pub fn poll_data(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<impl Buf>, Error>> {
+    pub fn poll_data(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<Bytes>, Error>> {
         if self.remaining_data == 0 {
             return Poll::Ready(Ok(None));
         };

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -317,7 +317,7 @@ impl<S, B> RequestStream<S, B>
 where
     S: quic::RecvStream,
 {
-    pub async fn recv_data(&mut self) -> Result<Option<impl Buf>, Error> {
+    pub async fn recv_data(&mut self) -> Result<Option<Bytes>, Error> {
         self.inner.recv_data().await
     }
 


### PR DESCRIPTION
frame.rs and buf.rs are hardcoded to providing Bytes anyways.

This is useful when writing the result to a hyper::Body channel since that only takes Bytes.