### PR TITLE
Fix problems with tests

### DIFF
--- a/tests/h3-tests/Cargo.toml
+++ b/tests/h3-tests/Cargo.toml
@@ -18,4 +18,4 @@ assert_matches = "1.5"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }
-quinn = { version = "0.8.0", default-features = false, features = ["tls-rustls"] }
+quinn = { version = "0.8.0", features = ["tls-rustls"] }

--- a/tests/h3-tests/tests/examples_server_client.rs
+++ b/tests/h3-tests/tests/examples_server_client.rs
@@ -10,6 +10,7 @@ fn server_and_client_should_connect_successfully() {
     command.push("../../target/debug/examples/server");
 
     let mut server = Command::new(command.as_path())
+        .arg("--listen=[::]:4433")
         .spawn()
         .expect("Failed to run server example");
     assert!(server.stderr.is_none(), "Failed to listen on localhost");


### PR DESCRIPTION
Hi, 
i had some problems with the tests.

1. Running single tests for example with  `cargo test --package h3-tests --test examples_server_client -- server_and_client_should_connect_successfully --exact --nocapture` failed with an compiler error. This was because the h3-tests quinn dependency was without the default features.
2. The `server_and_client_should_connect_successfully ` failed also on my local machine with Ubuntu 22.04. I am not sure but i think this was because `localhost` does not resolve to `[::1]`. With the current setting i think this works everywhere. 
