### PR TITLE
Generate links to spec sections

### DIFF
--- a/.github/actions/compliance/action.yml
+++ b/.github/actions/compliance/action.yml
@@ -62,9 +62,9 @@ runs:
         git config --local user.name "github-actions[bot]"
 
         if git ls-remote --exit-code --heads origin gh-pages; then
-          cp -r .github ci h3 target
+          cp -r .github ci h3 tests target
           git switch gh-pages
-          cp -r target/.github target/ci target/h3 .
+          cp -r target/.github target/ci target/h3 target/tests .
         else
           git checkout --orphan gh-pages
           git reset

--- a/ci/compliance/extract.sh
+++ b/ci/compliance/extract.sh
@@ -4,9 +4,9 @@ set -e
 
 ./target/release/duvet \
     extract \
-    ci/compliance/specs/rfc9114.txt \
+    https://www.rfc-editor.org/rfc/rfc9114 \
     --format "IETF" \
     --out "." \
     --extension "toml"
 
-echo "compliance checks available in 'ci/compliance/specs/rfc9114/'"
+echo "compliance checks available in 'specs/www.rfc-editor.org/rfc/rfc9114/'"

--- a/ci/compliance/report.sh
+++ b/ci/compliance/report.sh
@@ -8,6 +8,7 @@ BLOB=${1:-master}
   report \
   --spec-pattern 'specs/**/*.toml' \
   --source-pattern 'h3/**/*.rs' \
+  --source-pattern 'tests/**/*.rs' \
   --workspace \
   --exclude duvet \
   --require-tests false \

--- a/ci/compliance/report.sh
+++ b/ci/compliance/report.sh
@@ -6,7 +6,7 @@ BLOB=${1:-master}
 
 ./target/release/duvet \
   report \
-  --spec-pattern 'ci/compliance/specs/**/*.toml' \
+  --spec-pattern 'specs/**/*.toml' \
   --source-pattern 'h3/**/*.rs' \
   --workspace \
   --exclude duvet \


### PR DESCRIPTION
One last fix for the compliance report.

Just realized that the target argument to `duvet extract` is also used as the **reference/link** in the comments that are generated from the compliance report, which should be used as is so that the comment will be treated as an effective citation. I guess for ergonomics, we should probably pass the spec link to `duvet extract`, instead of the local path of the spec txt. Am I missing anything? @camshaft

But then the action will need to fetch the spec page on every run. We could commit the extracted specs instead, if you prefer otherwise. @seanmonstar 