### PR TITLE
Feed compliance report generator

### DIFF
--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -28,7 +28,6 @@ where
     O: quic::OpenStreams<Bytes>,
 {
     //= https://www.rfc-editor.org/rfc/rfc9114#section-3.3
-    //= type=implication
     //# Clients SHOULD NOT open more than one HTTP/3 connection to a given IP
     //# address and UDP port, where the IP address and port might be derived
     //# from a URI, a selected alternative service ([ALTSVC]), a configured
@@ -79,7 +78,6 @@ where
         let headers = Header::request(method, uri, headers)?;
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-4.1
-        //= type=implication
         //# A
         //# client MUST send only a single request on a given stream.
         let mut stream = future::poll_fn(|cx| self.open.poll_open_bidi(cx))

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -193,12 +193,6 @@ where
 {
     pub async fn shutdown(&mut self, max_requests: usize) -> Result<(), Error> {
         self.inner.shutdown(max_requests).await
-
-        //= https://www.rfc-editor.org/rfc/rfc9114#section-5.2
-        //= type=TODO
-        //# An endpoint that completes a
-        //# graceful shutdown SHOULD use the H3_NO_ERROR error code when closing
-        //# the connection.
     }
 
     pub async fn wait_idle(&mut self) -> Result<(), Error> {

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -243,6 +243,11 @@ where
             }
         }
 
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-6.1
+        //# Clients MUST treat
+        //# receipt of a server-initiated bidirectional stream as a connection
+        //# error of type H3_STREAM_CREATION_ERROR unless such an extension has
+        //# been negotiated.
         if self.inner.poll_accept_request(cx).is_ready() {
             return Poll::Ready(Err(self.inner.close(
                 Code::H3_STREAM_CREATION_ERROR,

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -27,6 +27,12 @@ where
     C: quic::Connection<Bytes, OpenStreams = O>,
     O: quic::OpenStreams<Bytes>,
 {
+    //= https://www.rfc-editor.org/rfc/rfc9114#section-3.3
+    //= type=implication
+    //# Clients SHOULD NOT open more than one HTTP/3 connection to a given IP
+    //# address and UDP port, where the IP address and port might be derived
+    //# from a URI, a selected alternative service ([ALTSVC]), a configured
+    //# proxy, or name resolution of any of these.
     Builder::new().build(conn).await
 }
 

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -193,6 +193,12 @@ where
 {
     pub async fn shutdown(&mut self, max_requests: usize) -> Result<(), Error> {
         self.inner.shutdown(max_requests).await
+
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-5.2
+        //= type=TODO
+        //# An endpoint that completes a
+        //# graceful shutdown SHOULD use the H3_NO_ERROR error code when closing
+        //# the connection.
     }
 
     pub async fn wait_idle(&mut self) -> Result<(), Error> {

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -142,7 +142,6 @@ where
         //# stream.
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.4
-        //= type=implication
         //# A SETTINGS frame MUST be sent as the first frame of
         //# each control stream (see Section 6.2.1) by each peer, and it MUST NOT
         //# be sent subsequently.
@@ -184,7 +183,9 @@ where
         if grease {
             //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.8
             //= type=implication
-            //# These frames have no semantics, and
+            //# Frame types of the format 0x1f * N + 0x21 for non-negative integer
+            //# values of N are reserved to exercise the requirement that unknown
+            //# types be ignored (Section 9).  These frames have no semantics, and
             //# they MAY be sent on any stream where frames are allowed to be sent.
             conn_inner.start_grease_stream().await;
         }

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -118,6 +118,10 @@ where
             }
         }
 
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-3.2
+        //# After the QUIC connection is
+        //# established, a SETTINGS frame MUST be sent by each endpoint as the
+        //# initial frame of their respective HTTP control stream.
         stream::write(
             &mut control_send,
             (StreamType::CONTROL, Frame::Settings(settings)),
@@ -153,6 +157,12 @@ where
 
         self.shared.write("graceful shutdown").closing = Some(max_id);
 
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-3.3
+        //# When either endpoint chooses to close the HTTP/3
+        //# connection, the terminating endpoint SHOULD first send a GOAWAY frame
+        //# (Section 5.2) so that both endpoints can reliably determine whether
+        //# previously sent frames have been processed and gracefully complete or
+        //# terminate any necessary remaining tasks.
         stream::write(&mut self.control_send, Frame::Goaway(max_id)).await
     }
 

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -147,12 +147,10 @@ where
         //# be sent subsequently.
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.4
-        //= type=implication
         //# SETTINGS frames MUST NOT be sent on any stream other than the control
         //# stream.
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.4.2
-        //= type=implication
         //# Endpoints MUST NOT require any data to be received from
         //# the peer prior to sending the SETTINGS frame; settings MUST be sent
         //# as soon as the transport is ready to send data.
@@ -163,7 +161,6 @@ where
         .await?;
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-6.2.1
-        //= type=implication
         //# The
         //# sender MUST NOT close the control stream, and the receiver MUST NOT
         //# request that the sender close the control stream.
@@ -182,7 +179,6 @@ where
         // start a grease stream
         if grease {
             //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.8
-            //= type=implication
             //# Frame types of the format 0x1f * N + 0x21 for non-negative integer
             //# values of N are reserved to exercise the requirement that unknown
             //# types be ignored (Section 9).  These frames have no semantics, and
@@ -257,7 +253,6 @@ where
 
         for (removed, index) in resolved.into_iter().enumerate() {
             //= https://www.rfc-editor.org/rfc/rfc9114#section-6.2
-            //= type=implication
             //# As certain stream types can affect connection state, a recipient
             //# SHOULD NOT discard data from incoming unidirectional streams prior to
             //# reading the stream type.
@@ -294,7 +289,6 @@ where
                 }
 
                 //= https://www.rfc-editor.org/rfc/rfc9114#section-6.2.3
-                //= type=implication
                 //# Endpoints MUST NOT consider these streams to have any meaning upon
                 //# receipt.
                 _ => (),
@@ -349,12 +343,10 @@ where
                         self.got_peer_settings = true;
 
                         //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.4
-                        //= type=implication
                         //# An implementation MUST ignore any parameter with an identifier it
                         //# does not understand.
 
                         //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.4.1
-                        //= type=implication
                         //# Endpoints MUST NOT consider such settings to have
                         //# any meaning upon receipt.
                         self.shared
@@ -428,7 +420,6 @@ where
                     //# connection error of type H3_FRAME_UNEXPECTED.
 
                     //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.1
-                    //= type=implication
                     //# DATA frames MUST be associated with an HTTP request or response.
 
                     //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.1

--- a/h3/src/proto/frame.rs
+++ b/h3/src/proto/frame.rs
@@ -412,6 +412,9 @@ impl Settings {
             return Ok(());
         }
 
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.4
+        //# The same setting identifier MUST NOT occur more than once in the
+        //# SETTINGS frame.
         if self.entries[..self.len].iter().any(|(i, _)| *i == id) {
             return Err(SettingsError::Repeated(id));
         }

--- a/h3/src/proto/headers.rs
+++ b/h3/src/proto/headers.rs
@@ -85,7 +85,6 @@ impl Header {
 
     pub fn into_response_parts(self) -> Result<(StatusCode, HeaderMap), Error> {
         //= https://www.rfc-editor.org/rfc/rfc9114#section-4.3.2
-        //= type=implication
         //# This pseudo-
         //# header field MUST be included in all responses; otherwise, the
         //# response is malformed (see Section 4.1.2).
@@ -285,7 +284,6 @@ where
 #[cfg_attr(test, derive(PartialEq, Clone))]
 struct Pseudo {
     //= https://www.rfc-editor.org/rfc/rfc9114#section-4.3
-    //= type=implication
     //# Endpoints MUST NOT
     //# generate pseudo-header fields other than those defined in this
     //# document.
@@ -313,7 +311,6 @@ impl Pseudo {
         } = uri::Parts::from(uri);
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-4.3.1
-        //= type=implication
         //# This pseudo-header field MUST NOT be empty for "http" or "https"
         //# URIs; "http" or "https" URIs that do not contain a path component
         //# MUST include a value of / (ASCII 0x2f).
@@ -331,13 +328,11 @@ impl Pseudo {
         let len = 3 + if authority.is_some() { 1 } else { 0 };
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-4.3
-        //= type=implication
         //# Pseudo-header fields defined for requests MUST NOT appear
         //# in responses; pseudo-header fields defined for responses MUST NOT
         //# appear in requests.
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-4.3.1
-        //= type=implication
         //# All HTTP/3 requests MUST include exactly one value for the :method,
         //# :scheme, and :path pseudo-header fields, unless the request is a
         //# CONNECT request; see Section 4.4.
@@ -353,7 +348,6 @@ impl Pseudo {
 
     fn response(status: StatusCode) -> Self {
         //= https://www.rfc-editor.org/rfc/rfc9114#section-4.3
-        //= type=implication
         //# Pseudo-header fields defined for requests MUST NOT appear
         //# in responses; pseudo-header fields defined for responses MUST NOT
         //# appear in requests.

--- a/h3/src/proto/headers.rs
+++ b/h3/src/proto/headers.rs
@@ -231,6 +231,15 @@ impl Field {
             return Err(Error::InvalidHeaderName("name is empty".into()));
         }
 
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-10.3
+        //# Requests or responses containing invalid field names MUST be treated
+        //# as malformed.
+
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-10.3
+        //# Any request or response that contains a
+        //# character not permitted in a field value MUST be treated as
+        //# malformed.
+
         if name[0] != b':' {
             return Ok(Field::Header((
                 HeaderName::from_bytes(name).map_err(|_| Error::invalid_name(name))?,

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -224,12 +224,6 @@ where
     /// See [Connection-Shutdown](https://httpwg.org/specs/rfc9114.html#connection-shutdown) for more information.
     pub async fn shutdown(&mut self, max_requests: usize) -> Result<(), Error> {
         self.inner.shutdown(max_requests).await
-
-        //= https://www.rfc-editor.org/rfc/rfc9114#section-5.2
-        //= type=TODO
-        //# An endpoint that completes a
-        //# graceful shutdown SHOULD use the H3_NO_ERROR error code when closing
-        //# the connection.
     }
 
     fn poll_accept_request(

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -219,6 +219,12 @@ where
     /// See [Connection-Shutdown](https://httpwg.org/specs/rfc9114.html#connection-shutdown) for more information.
     pub async fn shutdown(&mut self, max_requests: usize) -> Result<(), Error> {
         self.inner.shutdown(max_requests).await
+
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-5.2
+        //= type=TODO
+        //# An endpoint that completes a
+        //# graceful shutdown SHOULD use the H3_NO_ERROR error code when closing
+        //# the connection.
     }
 
     fn poll_accept_request(

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -356,6 +356,19 @@ where
     }
 }
 
+//= https://www.rfc-editor.org/rfc/rfc9114#section-6.1
+//= type=TODO
+//# In order to
+//# permit these streams to open, an HTTP/3 server SHOULD configure non-
+//# zero minimum values for the number of permitted streams and the
+//# initial stream flow-control window.
+
+//= https://www.rfc-editor.org/rfc/rfc9114#section-6.1
+//= type=TODO
+//# So as to not unnecessarily limit
+//# parallelism, at least 100 request streams SHOULD be permitted at a
+//# time.
+
 /// Use this struct to create a new [`Connection`].
 /// All the settings for the [`Connection`] can be provided here.
 ///
@@ -379,19 +392,6 @@ where
 pub struct Builder {
     pub(super) max_field_section_size: u64,
     pub(super) send_grease: bool,
-
-    //= https://www.rfc-editor.org/rfc/rfc9114#section-6.1
-    //= type=TODO
-    //# In order to
-    //# permit these streams to open, an HTTP/3 server SHOULD configure non-
-    //# zero minimum values for the number of permitted streams and the
-    //# initial stream flow-control window.
-
-    //= https://www.rfc-editor.org/rfc/rfc9114#section-6.1
-    //= type=TODO
-    //# So as to not unnecessarily limit
-    //# parallelism, at least 100 request streams SHOULD be permitted at a
-    //# time.
 }
 
 impl Builder {

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -356,6 +356,19 @@ where
 pub struct Builder {
     pub(super) max_field_section_size: u64,
     pub(super) send_grease: bool,
+
+    //= https://www.rfc-editor.org/rfc/rfc9114#section-6.1
+    //= type=TODO
+    //# In order to
+    //# permit these streams to open, an HTTP/3 server SHOULD configure non-
+    //# zero minimum values for the number of permitted streams and the
+    //# initial stream flow-control window.
+
+    //= https://www.rfc-editor.org/rfc/rfc9114#section-6.1
+    //= type=TODO
+    //# So as to not unnecessarily limit
+    //# parallelism, at least 100 request streams SHOULD be permitted at a
+    //# time.
 }
 
 impl Builder {

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -152,6 +152,11 @@ where
             //= https://www.rfc-editor.org/rfc/rfc9114#section-4.1
             //# Receipt of an invalid sequence of frames MUST be treated as a
             //# connection error of type H3_FRAME_UNEXPECTED.
+
+            //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.5
+            //# A server MUST treat the
+            //# receipt of a PUSH_PROMISE frame as a connection error of type
+            //# H3_FRAME_UNEXPECTED.
             Ok(Some(_)) => {
                 return Err(
                     Code::H3_FRAME_UNEXPECTED.with_reason("first request frame is not headers")
@@ -290,7 +295,25 @@ where
                 }
                 f @ Frame::MaxPushId(_) | f @ Frame::CancelPush(_) => {
                     warn!("Control frame ignored {:?}", f);
+
+                    //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.3
+                    //= type=TODO
+                    //# If a server receives a CANCEL_PUSH frame for a push
+                    //# ID that has not yet been mentioned by a PUSH_PROMISE frame, this MUST
+                    //# be treated as a connection error of type H3_ID_ERROR.
+
+                    //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.7
+                    //= type=TODO
+                    //# A MAX_PUSH_ID frame cannot reduce the maximum push
+                    //# ID; receipt of a MAX_PUSH_ID frame that contains a smaller value than
+                    //# previously received MUST be treated as a connection error of type
+                    //# H3_ID_ERROR.
                 }
+
+                //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.5
+                //# A server MUST treat the
+                //# receipt of a PUSH_PROMISE frame as a connection error of type
+                //# H3_FRAME_UNEXPECTED.
                 frame => {
                     return Poll::Ready(Err(Code::H3_FRAME_UNEXPECTED
                         .with_reason(format!("on server control stream: {:?}", frame))))

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -207,6 +207,25 @@ where
             StreamType::ENCODER => AcceptedRecvStream::Encoder(self.stream),
             StreamType::DECODER => AcceptedRecvStream::Decoder(self.stream),
             t if t.value() > 0x21 && (t.value() - 0x21) % 0x1f == 0 => AcceptedRecvStream::Reserved,
+
+            //= https://www.rfc-editor.org/rfc/rfc9114#section-6.2
+            //# Recipients of unknown stream types MUST
+            //# either abort reading of the stream or discard incoming data without
+            //# further processing.
+
+            //= https://www.rfc-editor.org/rfc/rfc9114#section-6.2
+            //# If reading is aborted, the recipient SHOULD use
+            //# the H3_STREAM_CREATION_ERROR error code or a reserved error code
+            //# (Section 8.1).
+
+            //= https://www.rfc-editor.org/rfc/rfc9114#section-6.2
+            //# The recipient MUST NOT consider unknown stream types
+            //# to be a connection error of any kind.
+
+            //= https://www.rfc-editor.org/rfc/rfc9114#section-6.2
+            //= type=implication
+            //# The recipient MUST NOT consider unknown stream types
+            //# to be a connection error of any kind.
             t => {
                 return Err(Code::H3_STREAM_CREATION_ERROR
                     .with_reason(format!("unknown stream type 0x{:x}", t.value())))

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -219,7 +219,6 @@ where
             //# (Section 8.1).
 
             //= https://www.rfc-editor.org/rfc/rfc9114#section-6.2
-            //= type=implication
             //# The recipient MUST NOT consider unknown stream types
             //# to be a connection error of any kind.
             t => {

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -219,10 +219,6 @@ where
             //# (Section 8.1).
 
             //= https://www.rfc-editor.org/rfc/rfc9114#section-6.2
-            //# The recipient MUST NOT consider unknown stream types
-            //# to be a connection error of any kind.
-
-            //= https://www.rfc-editor.org/rfc/rfc9114#section-6.2
             //= type=implication
             //# The recipient MUST NOT consider unknown stream types
             //# to be a connection error of any kind.

--- a/tests/h3-tests/tests/connection.rs
+++ b/tests/h3-tests/tests/connection.rs
@@ -397,6 +397,11 @@ async fn control_stream_frame_unexpected() {
         let new_connection = pair.client_inner().await;
         let mut control_stream = new_connection.connection.open_uni().await.unwrap();
 
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.1
+        //= type=test
+        //# If
+        //# a DATA frame is received on a control stream, the recipient MUST
+        //# respond with a connection error of type H3_FRAME_UNEXPECTED.
         let mut buf = BytesMut::new();
         StreamType::CONTROL.encode(&mut buf);
         Frame::Data(Bytes::from("")).encode(&mut buf);
@@ -458,6 +463,12 @@ async fn goaway_from_client_not_push_id() {
         let mut buf = BytesMut::new();
         StreamType::CONTROL.encode(&mut buf);
         Frame::<Bytes>::Settings(Settings::default()).encode(&mut buf);
+
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.6
+        //= type=test
+        //# A client MUST treat receipt of a GOAWAY frame containing a stream ID
+        //# of any other type as a connection error of type H3_ID_ERROR.
+
         // StreamId(index=0 << 2 | dir=Bi << 1 | initiator=Server as u64)
         Frame::<Bytes>::Goaway(StreamId(0u64 << 2 | 0 << 1 | 1)).encode(&mut buf);
         control_stream.write_all(&buf[..]).await.unwrap();
@@ -520,6 +531,12 @@ async fn goaway_from_server_not_request_id() {
         let mut buf = BytesMut::new();
         StreamType::CONTROL.encode(&mut buf);
         Frame::<Bytes>::Settings(Settings::default()).encode(&mut buf);
+
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.6
+        //= type=test
+        //# A client MUST treat receipt of a GOAWAY frame containing a stream ID
+        //# of any other type as a connection error of type H3_ID_ERROR.
+
         // StreamId(index=0 << 2 | dir=Uni << 1 | initiator=Server as u64)
         Frame::<Bytes>::Goaway(StreamId(0u64 << 2 | 0 << 1 | 1)).encode(&mut buf);
         control_stream.write_all(&buf[..]).await.unwrap();

--- a/tests/h3-tests/tests/request.rs
+++ b/tests/h3-tests/tests/request.rs
@@ -280,6 +280,10 @@ async fn header_too_big_response_from_server() {
 
     let server_fut = async {
         let conn = server.next().await;
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-4.2.2
+        //= type=test
+        //# An HTTP/3 implementation MAY impose a limit on the maximum size of
+        //# the message header it will accept on an individual HTTP message.
         let mut incoming_req = server::builder()
             .max_field_section_size(12)
             .build(conn)
@@ -340,6 +344,10 @@ async fn header_too_big_response_from_server_trailers() {
 
     let server_fut = async {
         let conn = server.next().await;
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-4.2.2
+        //= type=test
+        //# An HTTP/3 implementation MAY impose a limit on the maximum size of
+        //# the message header it will accept on an individual HTTP message.
         let mut incoming_req = server::builder()
             .max_field_section_size(207)
             .build(conn)
@@ -404,6 +412,10 @@ async fn header_too_big_client_error() {
 
     let server_fut = async {
         let conn = server.next().await;
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-4.2.2
+        //= type=test
+        //# An HTTP/3 implementation MAY impose a limit on the maximum size of
+        //# the message header it will accept on an individual HTTP message.
         server::builder()
             .max_field_section_size(12)
             .build(conn)
@@ -463,6 +475,10 @@ async fn header_too_big_client_error_trailer() {
 
     let server_fut = async {
         let conn = server.next().await;
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-4.2.2
+        //= type=test
+        //# An HTTP/3 implementation MAY impose a limit on the maximum size of
+        //# the message header it will accept on an individual HTTP message.
         let mut incoming_req = server::builder()
             .max_field_section_size(207)
             .build(conn)
@@ -488,6 +504,13 @@ async fn header_too_big_discard_from_client() {
     let mut server = pair.server();
 
     let client_fut = async {
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-4.2.2
+        //= type=test
+        //# An implementation that
+        //# has received this parameter SHOULD NOT send an HTTP message header
+        //# that exceeds the indicated size, as the peer will likely refuse to
+        //# process it.
+
         // Do not poll driver so client doesn't know about server's max_field section size setting
         let (_conn, mut client) = client::builder()
             .max_field_section_size(12)
@@ -566,6 +589,13 @@ async fn header_too_big_discard_from_client_trailers() {
     let mut server = pair.server();
 
     let client_fut = async {
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-4.2.2
+        //= type=test
+        //# An implementation that
+        //# has received this parameter SHOULD NOT send an HTTP message header
+        //# that exceeds the indicated size, as the peer will likely refuse to
+        //# process it.
+
         // Do not poll driver so client doesn't know about server's max_field section size setting
         let (mut driver, mut client) = client::builder()
             .max_field_section_size(200)
@@ -665,6 +695,13 @@ async fn header_too_big_server_error() {
 
         let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
 
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-4.2.2
+        //= type=test
+        //# An implementation that
+        //# has received this parameter SHOULD NOT send an HTTP message header
+        //# that exceeds the indicated size, as the peer will likely refuse to
+        //# process it.
+
         // pretend the server received a smaller max_field_section_size
         incoming_req
             .shared_state()
@@ -737,6 +774,13 @@ async fn header_too_big_server_error_trailers() {
             .send_data("wonderful hypertext".into())
             .await
             .expect("send_data");
+
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-4.2.2
+        //= type=test
+        //# An implementation that
+        //# has received this parameter SHOULD NOT send an HTTP message header
+        //# that exceeds the indicated size, as the peer will likely refuse to
+        //# process it.
 
         // pretend the server already received client's settings
         incoming_req
@@ -1096,8 +1140,10 @@ async fn request_valid_unkown_frame_after_trailers() {
     .await;
 }
 
-// [...]
-// Receipt of an invalid sequence of frames MUST be treated as a connection error of type H3_FRAME_UNEXPECTED
+//= https://www.rfc-editor.org/rfc/rfc9114#section-4.1
+//= type=test
+//# Receipt of an invalid sequence of frames MUST be treated as a
+//# connection error of type H3_FRAME_UNEXPECTED.
 fn invalid_request_frames() -> Vec<Frame<Bytes>> {
     vec![
         Frame::CancelPush(StreamId(0)),
@@ -1293,6 +1339,10 @@ where
     F: Fn(&mut BytesMut),
 {
     request_sequence_check(request, |err| {
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-4.1
+        //= type=test
+        //# Receipt of an invalid sequence of frames MUST be treated as a
+        //# connection error of type H3_FRAME_UNEXPECTED.
         assert_matches!(
             err.unwrap_err().kind(),
             Kind::Application {


### PR DESCRIPTION
Redoing #117 
* fixed broken anchors in spec links
* corrected some dislocated annotations
* applied a new annotation type [IMPLICATION](https://github.com/awslabs/duvet/blob/681f2b02178b2f9b98439ab4d9ff745ebbdf2375/src/annotation.rs#L142) for requirements whose related code is self-evident