### PR TITLE
Document everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ The eventual goal is to use `h3` as an internal dependency of [hyper][].
 * HTTP/3 client and server implementation
 * Async only API
 * QUIC transport abstraction via traits in the [`quic`](https://github.com/hyperium/h3/h3/src/quic.rs) module
-* The only supported QUIC implementation to date is [Quinn](https://github.com/quinn-rs/quinn)
+* Supported QUIC implementations to date are
+  [Quinn](https://github.com/quinn-rs/quinn) ([h3-quinn](/h3-quinn/))
+  and [s2n-quic](https://github.com/aws/s2n-quic)
+  ([s2n-quic-h3](https://github.com/aws/s2n-quic/tree/main/quic/s2n-quic-h3))
 
 ## Overview
 
@@ -54,7 +57,7 @@ while let Some((req, stream)) = h3_conn.accept().await? {
 endpoint.wait_idle();
 ```
 
-You can find a full server examples in [`examples/server.rs`](https://github.com/hyperium/h3/examples/server.rs)
+You can find a full server example in [`examples/server.rs`](https://github.com/hyperium/h3/examples/server.rs)
 
 ### Client
 
@@ -98,15 +101,14 @@ You can find a full client example in [`examples/client.rs`](https://github.com/
 
 As mentioned, the goal of this library is to be generic over a QUIC implementation. To that effect, integrations with QUIC libraries exist:
 
-- `h3-quinn`: in this same repository.
+- [`h3-quinn`](/h3-quinn/): in this same repository.
 - [`s2n-quic-h3`](https://github.com/aws/s2n-quic/tree/main/quic/s2n-quic-h3)
 
 ## Interoperability
 
-This crate as well as the quic implementation are [tested](https://github.com/quinn-rs/quinn-interop) for interoperability and performance in the [quic-interop-runner](https://github.com/marten-seemann/quic-interop-runner).
+This crate as well as the quic implementations are tested ([quinn](https://github.com/quinn-rs/quinn-interop), [s2n-quic](https://github.com/aws/s2n-quic/tree/main/scripts/interop)) for interoperability and performance in the [quic-interop-runner](https://github.com/marten-seemann/quic-interop-runner).
 You can see the results at (https://interop.seemann.io/).
 
 ## License
 
 h3 is provided under the MIT license. See [LICENSE](LICENSE).
-

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # h3
 
+An async HTTP/3 implementation.
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/hyperium/h3/workflows/CI/badge.svg)](https://github.com/hyperium/h3/actions?query=workflow%3ACI)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord)](https://discord.gg/q5mVhMD)
 
 This crate provides an [HTTP/3][spec] implementation that is generic over a provided QUIC transport. This allows the project to focus on just HTTP/3, while letting users pick their QUIC implementation based on their specific needs. It includes client and server APIs. Check the original [design][] for more details.
 
-[spec]: https://httpwg.org/specs/rfc9114.html
+[spec]: https://www.rfc-editor.org/rfc/rfc9114
 [design]: design/PROPOSAL.md
 
 ## Status
@@ -17,12 +19,80 @@ The eventual goal is to use `h3` as an internal dependency of [hyper][].
 
 [hyper]: https://hyper.rs
 
+## Features
+
+* HTTP/3 client and server implementation
+* Async only API
+* QUIC transport abstraction via traits in the [`quic`](https://github.com/hyperium/h3/h3/src/quic.rs) module
+* The only supported QUIC implementation to date is [Quinn](https://github.com/quinn-rs/quinn)
+
+## Overview
+
+* **h3** HTTP/3 implementation
+* **h3-quinn** QUIC transport implementation based on [Quinn](https://github.com/quinn-rs/quinn/)
+
 ## Getting Started
 
 The [examples](./examples) directory can help get started in two ways:
 
 - There are ready-to-use `client` and `server` binaries to interact with _other_ HTTP/3 peers. Check the README in that directory.
 - The source code of those examples can help teach how to use `h3` as either a client or a server.
+
+### Server
+
+```rust
+let (endpoint, mut incoming) = h3_quinn::quinn::Endpoint::server(server_config, "[::]:443".parse()?)?;
+
+while let Some((req, stream)) = h3_conn.accept().await? {
+   let resp = http::Response::builder().status(Status::OK).body(())?;
+   stream.send_response(resp).await?;
+
+   stream.send_data(Bytes::new("It works!")).await?;
+   stream.finish().await?;
+}
+
+endpoint.wait_idle();
+```
+
+You can find a full server examples in [`examples/server.rs`](https://github.com/hyperium/h3/examples/server.rs)
+
+### Client
+
+``` rust
+let addr: SocketAddr = "[::1]:443".parse()?;
+
+let quic = h3_quinn::Connection::new(client_endpoint.connect(addr, "server")?.await?);
+let (mut driver, mut send_request) = h3::client::new(quinn_conn).await?;
+
+let drive = async move {
+    future::poll_fn(|cx| driver.poll_close(cx)).await?;
+    Ok::<(), Box<dyn std::error::Error>>(())
+};
+
+let request = async move {
+    let req = http::Request::builder().uri(dest).body(())?;
+
+    let mut stream = send_request.send_request(req).await?;
+    stream.finish().await?;
+
+    let resp = stream.recv_response().await?;
+
+    while let Some(mut chunk) = stream.recv_data().await? {
+        let mut out = tokio::io::stdout();
+        out.write_all_buf(&mut chunk).await?;
+        out.flush().await?;
+    }
+    Ok::<_, Box<dyn std::error::Error>>(())
+};
+
+let (req_res, drive_res) = tokio::join!(request, drive);
+req_res?;
+drive_res?;
+
+client_endpoint.wait_idle().await;
+```
+
+You can find a full client example in [`examples/client.rs`](https://github.com/hyperium/h3/examples/client.rs)
 
 ## QUIC Generic
 
@@ -31,6 +101,10 @@ As mentioned, the goal of this library is to be generic over a QUIC implementati
 - `h3-quinn`: in this same repository.
 - [`s2n-quic-h3`](https://github.com/aws/s2n-quic/tree/main/quic/s2n-quic-h3)
 
+## Interoperability
+
+This crate as well as the quic implementation are [tested](https://github.com/quinn-rs/quinn-interop) for interoperability and performance in the [quic-interop-runner](https://github.com/marten-seemann/quic-interop-runner).
+You can see the results at (https://interop.seemann.io/).
 
 ## License
 

--- a/design/PROPOSAL.md
+++ b/design/PROPOSAL.md
@@ -82,9 +82,9 @@ HTTP/3 is a new networking protocol that defines HTTP semantics specifically ove
 - **QPACK dynamic table**: the dynamic table is a performance optimization, but has the potential to block streams waiting on dynamic table updates. To reduce initial complexity, and to not require figuring out the correct heuristic, we can delay integrating the dynamic table till later. HTTP/3 even defaults to expecting zero space in the dynamic table unless the peer opts-in.
 - **Server Push**
 - **HTTP CONNECT** to tunnel over a single QUIC stream
-- **Prioritization**: Stream priorities were defined in HTTP/2, and are especially useful for browsers to improve page load speeds. However, they are not specifically defined in QUIC or HTTP/3. There is a [different proposal][http-prio] that we should consider once stabilized.
+- **Prioritization**: Stream priorities were defined in HTTP/2, and are especially useful for browsers to improve page load speeds. However, they are not specifically defined in QUIC or HTTP/3. There is a [later RFC][http-prio] that we should consider instead.
 
-[http-prio]: https://tools.ietf.org/html/draft-ietf-httpbis-priority-01
+[http-prio]: https://www.rfc-editor.org/rfc/rfc9218.html
 
 
 ## 4. Public API
@@ -299,7 +299,7 @@ trait BidiStream<B>: SendStream<B> + RecvStream {
 
 ## 6. Security Considerations
 
-The HTTP/3 draft mentions several [security considerations](https://quicwg.org/base-drafts/draft-ietf-quic-http.html#name-security-considerations), this explains how each are handled.
+The HTTP/3 RFC mentions several [security considerations](https://www.rfc-editor.org/rfc/rfc9114.html#name-security-considerations), this explains how each are handled.
 
 
 1. **Server authority**: deciding if a server should accept a given authority is punted to the user of the library.

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -120,8 +120,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         while let Some(mut chunk) = stream.recv_data().await? {
             let mut out = tokio::io::stdout();
-            out.write_all_buf(&mut chunk).await.expect("write_all");
-            out.flush().await.expect("flush");
+            out.write_all_buf(&mut chunk).await?;
+            out.flush().await?;
         }
         Ok::<_, Box<dyn std::error::Error>>(())
     };

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -18,10 +18,12 @@ use crate::{
     qpack, quic, stream,
 };
 
+/// Start building a new HTTP/3 client
 pub fn builder() -> Builder {
     Builder::new()
 }
 
+/// Create a new HTTP/3 client with default settings
 pub async fn new<C, O>(conn: C) -> Result<(Connection<C, Bytes>, SendRequest<O, Bytes>), Error>
 where
     C: quic::Connection<Bytes, OpenStreams = O>,
@@ -35,6 +37,83 @@ where
     Builder::new().build(conn).await
 }
 
+/// HTTP/3 request sender
+///
+/// [`send_request()`] initiates a new request and will resolve when it is ready to be sent
+/// to the server. Then a [`RequestStream`] will be returned to send a request body (for
+/// POST, PUT methods) and receive a response. After the whole body is sent, it is necessary
+/// to call [`RequestStream::finish()`] to let the server know the request transfer is complete.
+/// This includes the cases where no nody is sent at all.
+///
+/// This struct is cloneable so multiple requests can be sent concurrently.
+///
+/// Existing instances are atomically counted internally, so whenever all of them have been
+/// dropped, the connection will be automatically closed whith HTTP/3 connection error code
+/// `HTTP_NO_ERROR = 0`.
+///
+/// # Examples
+///
+/// ## Sending a request with no body
+///
+/// ```rust
+/// # use h3::{quic, client::*};
+/// # use http::{Request, Response};
+/// # use bytes::Buf;
+/// # async fn doc<T,B>(mut send_request: SendRequest<T, B>) -> Result<(), Box<dyn std::error::Error>>
+/// # where
+/// #     T: quic::OpenStreams<B>,
+/// #     B: Buf,
+/// # {
+/// // Prepare the HTTP request to send to the server
+/// let request = Request::get("https://www.example.com/").body(())?;
+///
+/// // Send the request to the server
+/// let mut req_stream: RequestStream<_, _> = send_request.send_request(request).await?;
+/// // Don't forget to end up the request by finishing the send stream.
+/// req_stream.finish().await?;
+/// // Receive the response
+/// let response: Response<()> = req_stream.recv_response().await?;
+/// // Process the response...
+/// # Ok(())
+/// # }
+/// # pub fn main() {}
+/// ```
+///
+/// ## Sending a request with a body and trailers
+///
+/// ```rust
+/// # use h3::{quic, client::*};
+/// # use http::{Request, Response, HeaderMap};
+/// # use bytes::{Buf, Bytes};
+/// # async fn doc<T,B>(mut send_request: SendRequest<T, Bytes>) -> Result<(), Box<dyn std::error::Error>>
+/// # where
+/// #     T: quic::OpenStreams<Bytes>,
+/// # {
+/// // Prepare the HTTP request to send to the server
+/// let request = Request::get("https://www.example.com/").body(())?;
+///
+/// // Send the request to the server
+/// let mut req_stream = send_request.send_request(request).await?;
+/// // Send some data
+/// req_stream.send_data("body".into()).await?;
+/// // Prepare the trailers
+/// let mut trailers = HeaderMap::new();
+/// trailers.insert("trailer", "value".parse()?);
+/// // Send them and finish the send stream
+/// req_stream.send_trailers(trailers).await?;
+/// // We don't need to finish the send stream, as `send_trailers()` did it for us
+///
+/// // Receive the response.
+/// let response = req_stream.recv_response().await?;
+/// // Process the response...
+/// # Ok(())
+/// # }
+/// # pub fn main() {}
+/// ```
+///
+/// [`send_request()`]: struct.SendRequest.html#method.send_request
+/// [`RequestStream`]: struct.RequestStream.html
+/// [`RequestStream::finish()`]: struct.RequestStream.html#method.finish
 pub struct SendRequest<T, B>
 where
     T: quic::OpenStreams<B>,
@@ -55,6 +134,7 @@ where
     T: quic::OpenStreams<B>,
     B: Buf,
 {
+    /// Send a HTTP/3 request to the server
     pub async fn send_request(
         &mut self,
         req: http::Request<()>,
@@ -176,6 +256,88 @@ where
     }
 }
 
+/// Client connection driver
+///
+/// Maintains the internal state of an HTTP/3 connection, including control and QPACK.
+/// It needs to be polled continously via [`poll_close()`]. On connection closure, this
+/// will resolve to `Ok(())` if the peer sent `HTTP_NO_ERROR`, or `Err()` if a connection-level
+/// error occured.
+///
+/// [`shutdown()`] initiates a graceful shutdown of this connection. After calling it, no request
+/// initiation will be further allowed. Then [`poll_close()`] will resolve when all ongoing requests
+/// and push streams complete. Finally, a connection closure with `HTTP_NO_ERROR` code will be
+/// sent to the server.
+///
+/// # Examples
+///
+/// ## Drive a connection concurrenty
+///
+/// ```rust
+/// # use bytes::Buf;
+/// # use futures_util::future;
+/// # use h3::{client::*, quic};
+/// # use tokio::task::JoinHandle;
+/// # async fn doc<C, B>(mut connection: Connection<C, B>)
+/// #    -> JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>
+/// # where
+/// #    C: quic::Connection<B> + Send + 'static,
+/// #    C::SendStream: Send + 'static,
+/// #    C::RecvStream: Send + 'static,
+/// #    B: Buf + Send + 'static,
+/// # {
+/// // Run the driver on a different task
+/// tokio::spawn(async move {
+///     future::poll_fn(|cx| connection.poll_close(cx)).await?;
+///     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+/// })
+/// # }
+/// ```
+///
+/// ## Shutdown a connection gracefully
+///
+/// ```rust
+/// # use bytes::Buf;
+/// # use futures_util::future;
+/// # use h3::{client::*, quic};
+/// # use tokio::{self, sync::oneshot, task::JoinHandle};
+/// # async fn doc<C, B>(mut connection: Connection<C, B>)
+/// #    -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+/// # where
+/// #    C: quic::Connection<B> + Send + 'static,
+/// #    C::SendStream: Send + 'static,
+/// #    C::RecvStream: Send + 'static,
+/// #    B: Buf + Send + 'static,
+/// # {
+/// // Prepare a channel to stop the driver thread
+/// let (shutdown_tx, shutdown_rx) = oneshot::channel();
+///
+/// // Run the driver on a different task
+/// let driver = tokio::spawn(async move {
+///     tokio::select! {
+///         // Drive the connection
+///         closed = future::poll_fn(|cx| connection.poll_close(cx)) => closed?,
+///         // Listen for shutdown condition
+///         max_streams = shutdown_rx => {
+///             // Initiate shutdown
+///             connection.shutdown(max_streams?);
+///             // Wait for ongoing work to complete
+///             future::poll_fn(|cx| connection.poll_close(cx)).await?;
+///         }
+///     };
+///
+///     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+/// });
+///
+/// // Do client things, wait for close contition...
+///
+/// // Initiate shutdown
+/// shutdown_tx.send(2);
+/// // Wait for the connection to be closed
+/// driver.await?
+/// # }
+/// ```
+/// [`poll_close()`]: struct.Connection.html#method.poll_close
+/// [`shutdown()`]: struct.Connection.html#method.shutdown
 pub struct Connection<C, B>
 where
     C: quic::Connection<B>,
@@ -189,14 +351,17 @@ where
     C: quic::Connection<B>,
     B: Buf,
 {
+    /// Itiniate a graceful shutdown, accepting `max_request` potentially in-flight server push
     pub async fn shutdown(&mut self, max_requests: usize) -> Result<(), Error> {
         self.inner.shutdown(max_requests).await
     }
 
+    /// Wait until the connection is closed
     pub async fn wait_idle(&mut self) -> Result<(), Error> {
         future::poll_fn(|cx| self.poll_close(cx)).await
     }
 
+    /// Maintain the connection state until it is closed
     pub fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
         while let Poll::Ready(result) = self.inner.poll_control(cx) {
             match result {
@@ -287,6 +452,26 @@ where
     }
 }
 
+/// HTTP/3 client builder
+///
+/// Set the configuration for a new client.
+///
+/// # Examples
+/// ```rust
+/// # use h3::quic;
+/// # async fn doc<C, O, B>(quic: C)
+/// # where
+/// #   C: quic::Connection<B, OpenStreams = O>,
+/// #   O: quic::OpenStreams<B>,
+/// #   B: bytes::Buf,
+/// # {
+/// let h3_conn = h3::client::builder()
+///     .max_field_section_size(8192)
+///     .build(quic)
+///     .await
+///     .expect("Failed to build connection");
+/// # }
+/// ```
 pub struct Builder {
     max_field_section_size: u64,
     send_grease: bool,
@@ -300,11 +485,17 @@ impl Builder {
         }
     }
 
+    /// Set the maximum header size this client is willing to accepte
+    ///
+    /// See [header size constraints] section of the specification for details.
+    ///
+    /// [header size constraints]: https://quicwg.org/base-drafts/draft-ietf-quic-http.html#name-header-size-constraints
     pub fn max_field_section_size(&mut self, value: u64) -> &mut Self {
         self.max_field_section_size = value;
         self
     }
 
+    /// Create a new HTTP/3 client from a `quic` connection
     pub async fn build<C, O, B>(
         &mut self,
         quic: C,
@@ -342,6 +533,59 @@ impl Builder {
     }
 }
 
+/// Manage request bodies transfer, response and trailers.
+///
+/// Once a request has been sent via [`send_request()`], a response can be awaited by calling
+/// [`recv_response()`]. A body for this request can be sent with [`send_data()`], then the request
+/// shall be completed by either sending trailers with [`send_trailers()`], or [`finish()`].
+///
+/// After receiving the response's headers, it's body can be read by [`recv_data()`] until it returns
+/// `None`. Then the trailers will eventually be available via [`recv_trailers()`].
+///
+/// TODO: If data is polled before the response has been received, an error will be thrown.
+///
+/// TODO: If trailers are polled but the body hasn't been fully received, an UNEXPECT_FRAME error will be
+/// thrown
+///
+/// Whenever the client wants to cancel this request, it can call [`stop_sending()`], which will
+/// put an end to any transfer concerning it.
+///
+/// # Examples
+///
+/// ```rust
+/// # use h3::{quic, client::*};
+/// # use http::{Request, Response};
+/// # use bytes::Buf;
+/// # use tokio::io::AsyncWriteExt;
+/// # async fn doc<T,B>(mut req_stream: RequestStream<T, B>) -> Result<(), Box<dyn std::error::Error>>
+/// # where
+/// #     T: quic::RecvStream,
+/// #     B: Buf,
+/// # {
+/// // Prepare the HTTP request to send to the server
+/// let request = Request::get("https://www.example.com/").body(())?;
+///
+/// // Receive the response
+/// let response = req_stream.recv_response().await?;
+/// // Receive the body
+/// while let Some(mut chunk) = req_stream.recv_data().await? {
+///     let mut out = tokio::io::stdout();
+///     out.write_all_buf(&mut chunk).await?;
+///     out.flush().await?;
+/// }
+/// # Ok(())
+/// # }
+/// # pub fn main() {}
+/// ```
+///
+/// [`send_request()`]: struct.SendRequest.html#method.send_request
+/// [`recv_response()`]: #method.recv_response
+/// [`recv_data()`]: #method.recv_data
+/// [`send_data()`]: #method.send_data
+/// [`send_trailers()`]: #method.send_trailers
+/// [`recv_trailers()`]: #method.recv_trailers
+/// [`finish()`]: #method.finish
+/// [`stop_sending()`]: #method.stop_sending
 pub struct RequestStream<S, B> {
     inner: connection::RequestStream<S, B>,
 }
@@ -356,6 +600,11 @@ impl<S, B> RequestStream<S, B>
 where
     S: quic::RecvStream,
 {
+    /// Receive the HTTP/3 response
+    ///
+    /// This should be called before trying to receive any data with [`recv_data()`].
+    ///
+    /// [`recv_data()`]: #method.recv_data
     pub async fn recv_response(&mut self) -> Result<Response<()>, Error> {
         let mut frame = future::poll_fn(|cx| self.inner.stream.poll_next(cx))
             .await
@@ -413,6 +662,8 @@ where
         Ok(resp)
     }
 
+    ///
+    // TODO what if called before recv_response ?
     pub async fn recv_data(&mut self) -> Result<Option<impl Buf>, Error> {
         self.inner.recv_data().await
     }
@@ -428,6 +679,8 @@ where
     }
 
     pub fn stop_sending(&mut self, error_code: crate::error::Code) {
+        // TODO take by value to prevent any further call as this request is cancelled
+        // rename `cancel()` ?
         self.inner.stream.stop_sending(error_code)
     }
 }

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -491,7 +491,7 @@ impl Builder {
     ///
     /// See [header size constraints] section of the specification for details.
     ///
-    /// [header size constraints]: https://quicwg.org/base-drafts/draft-ietf-quic-http.html#name-header-size-constraints
+    /// [header size constraints]: https://www.rfc-editor.org/rfc/rfc9114.html#name-header-size-constraints
     pub fn max_field_section_size(&mut self, value: u64) -> &mut Self {
         self.max_field_section_size = value;
         self

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -45,7 +45,7 @@ where
 /// to the server. Then a [`RequestStream`] will be returned to send a request body (for
 /// POST, PUT methods) and receive a response. After the whole body is sent, it is necessary
 /// to call [`RequestStream::finish()`] to let the server know the request transfer is complete.
-/// This includes the cases where no nody is sent at all.
+/// This includes the cases where no body is sent at all.
 ///
 /// This struct is cloneable so multiple requests can be sent concurrently.
 ///

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -115,8 +115,15 @@ where
             .insert(SettingId::MAX_HEADER_LIST_SIZE, max_field_section_size)
             .map_err(|e| Code::H3_INTERNAL_ERROR.with_cause(e))?;
 
-        // Grease Settings (https://httpwg.org/specs/rfc9114.html#rfc.section.7.2.4.1)
         if grease {
+            //  Grease Settings (https://www.rfc-editor.org/rfc/rfc9114.html#name-defined-settings-parameters)
+            //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.4.1
+            //# Setting identifiers of the format 0x1f * N + 0x21 for non-negative
+            //# integer values of N are reserved to exercise the requirement that
+            //# unknown identifiers be ignored.  Such settings have no defined
+            //# meaning.  Endpoints SHOULD include at least one such setting in their
+            //# SETTINGS frame.
+
             //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.4.1
             //# Setting identifiers that were defined in [HTTP/2] where there is no
             //# corresponding HTTP/3 setting have also been reserved
@@ -458,7 +465,7 @@ where
     }
 
     /// starts an grease stream
-    /// https://httpwg.org/specs/rfc9114.html#stream-grease
+    /// https://www.rfc-editor.org/rfc/rfc9114.html#stream-grease
     async fn start_grease_stream(&mut self) {
         // start the stream
         let mut grease_stream = match future::poll_fn(|cx| self.conn.poll_open_send(cx))

--- a/h3/src/error.rs
+++ b/h3/src/error.rs
@@ -44,7 +44,7 @@ pub(crate) struct ErrorImpl {
 }
 
 /// Some errors affect the whole connection, others only one Request or Stream.
-/// See [errors](https://httpwg.org/specs/rfc9114.html#errors) for mor details.
+/// See [errors](https://www.rfc-editor.org/rfc/rfc9114.html#errors) for mor details.
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub enum ErrorLevel {
     /// Error that will close the whole connection

--- a/h3/src/error.rs
+++ b/h3/src/error.rs
@@ -22,6 +22,10 @@ pub struct Code {
 }
 
 impl Code {
+    /// Numerical error code
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc9114.html#errors>
+    /// and <https://www.rfc-editor.org/rfc/rfc9000.html#error-codes>
     pub fn value(&self) -> u64 {
         self.code
     }
@@ -39,13 +43,13 @@ pub(crate) struct ErrorImpl {
     cause: Option<Arc<Cause>>,
 }
 
-/// Some errors affect the hole connection, others only one Request or Stream.
+/// Some errors affect the whole connection, others only one Request or Stream.
 /// See [errors](https://httpwg.org/specs/rfc9114.html#errors) for mor details.
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub enum ErrorLevel {
-    // connection error
+    /// Error that will close the whole connection
     ConnectionError,
-    // stream error
+    /// Error scoped to a single stream
     StreamError,
 }
 
@@ -269,6 +273,7 @@ impl Error {
     }
 
     #[cfg(feature = "test_helpers")]
+    #[doc(hidden)]
     pub fn kind(&self) -> Kind {
         self.inner.kind.clone()
     }

--- a/h3/src/lib.rs
+++ b/h3/src/lib.rs
@@ -1,7 +1,11 @@
+//! HTTP/3 client and server
+#[deny(missing_docs)]
 pub mod client;
+#[deny(missing_docs)]
 pub mod error;
 #[deny(missing_docs)]
 pub mod quic;
+#[deny(missing_docs)]
 pub mod server;
 
 pub use error::Error;
@@ -15,6 +19,7 @@ mod qpack;
 mod stream;
 
 #[cfg(feature = "test_helpers")]
+#[doc(hidden)]
 pub mod test_helpers {
     pub mod qpack {
         pub use crate::qpack::*;

--- a/h3/src/qpack/decoder.rs
+++ b/h3/src/qpack/decoder.rs
@@ -80,7 +80,8 @@ pub struct Decoder {
 }
 
 impl Decoder {
-    // Decode a header bloc received on Request of Push stream. (draft: 4.5)
+    // Decode field lines received on Request of Push stream.
+    // https://www.rfc-editor.org/rfc/rfc9204.html#name-field-line-representations
     pub fn decode_header<T: Buf>(&self, buf: &mut T) -> Result<Decoded, Error> {
         let (required_ref, base) = HeaderPrefix::decode(buf)?
             .get(self.table.total_inserted(), self.table.max_mem_size())?;
@@ -206,7 +207,8 @@ impl Decoder {
     }
 }
 
-// Decode a header bloc received on Request or Push stream. (draft: 4.5)
+// Decode field lines received on Request or Push stream.
+// https://www.rfc-editor.org/rfc/rfc9204.html#name-field-line-representations
 pub fn decode_stateless<T: Buf>(buf: &mut T, max_size: u64) -> Result<Decoded, Error> {
     let (required_ref, _base) = HeaderPrefix::decode(buf)?.get(0, 0)?;
 
@@ -344,8 +346,8 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-00
-     * 4.3.1.  Insert With Name Reference
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-insert-with-name-reference
+     * 4.3.2.  Insert With Name Reference
      */
     #[test]
     fn test_insert_field_with_name_ref_into_dynamic_table() {
@@ -371,8 +373,8 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-00
-     * 4.3.1.  Insert With Name Reference
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-insert-with-name-reference
+     * 4.3.2.  Insert With Name Reference
      */
     #[test]
     fn test_insert_field_with_wrong_name_index_from_static_table() {
@@ -387,8 +389,8 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-00
-     * 4.3.1.  Insert With Name Reference
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-insert-with-name-referencehtml
+     * 4.3.2.  Insert With Name Reference
      */
     #[test]
     fn test_insert_field_with_wrong_name_index_from_dynamic_table() {
@@ -411,8 +413,8 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-00
-     * 4.3.2.  Insert Without Name Reference
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-insert-with-literal-name
+     * 4.3.3.  Insert with Literal Name
      */
     #[test]
     fn test_insert_field_without_name_ref() {
@@ -445,8 +447,8 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-00
-     * 4.3.3.  Duplicate
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-duplicate
+     * 4.3.4.  Duplicate
      */
     #[test]
     fn test_duplicate_field() {
@@ -474,8 +476,8 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-00
-     * 4.3.4.  Dynamic Table Size Update
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-set-dynamic-table-capacity
+     * 4.3.1.  Set Dynamic Table Capacity
      */
     #[test]
     fn test_dynamic_table_size_update() {

--- a/h3/src/qpack/dynamic.rs
+++ b/h3/src/qpack/dynamic.rs
@@ -7,7 +7,7 @@ use super::{field::HeaderField, static_::StaticTable};
 use crate::qpack::vas::{self, VirtualAddressSpace};
 
 /**
- * https://httpwg.org/specs/rfc9204.html#maximum-dynamic-table-capacity
+ * https://www.rfc-editor.org/rfc/rfc9204.html#maximum-dynamic-table-capacity
  */
 const SETTINGS_MAX_TABLE_CAPACITY_MAX: usize = 1_073_741_823; // 2^30 -1
 const SETTINGS_MAX_BLOCKED_STREAMS_MAX: usize = 65_535; // 2^16 - 1
@@ -562,11 +562,12 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-01#section-2.2
-     * "The decoder determines the maximum size that the encoder is permitted
-     *  to use for the dynamic table.  In HTTP/QUIC, this value is determined
-     *  by the SETTINGS_HEADER_TABLE_SIZE setting (see Section 4.2.5.2 of
-     *  [QUIC-HTTP])."
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-maximum-dynamic-table-capac
+     * "To bound the memory requirements of the decoder, the decoder
+     * limits the maximum value the encoder is permitted to set for the
+     * dynamic table capacity. In HTTP/3, this limit is determined by
+     * the value of SETTINGS_QPACK_MAX_TABLE_CAPACITY sent by the
+     * decoder; see Section 5."
      */
     #[test]
     fn test_try_set_too_large_maximum_table_size() {
@@ -577,7 +578,7 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-01#section-2.2
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-dynamic-table-capacity-and-
      * "This mechanism can be used to completely clear entries from the
      *  dynamic table by setting a maximum size of 0, which can subsequently
      *  be restored."
@@ -591,11 +592,12 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-01#section-2.2
-     * "The decoder determines the maximum size that the encoder is permitted
-     *  to use for the dynamic table.  In HTTP/QUIC, this value is determined
-     *  by the SETTINGS_HEADER_TABLE_SIZE setting (see Section 4.2.5.2 of
-     *  [QUIC-HTTP])."
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-maximum-dynamic-table-capac
+     * "To bound the memory requirements of the decoder, the decoder
+     * limits the maximum value the encoder is permitted to set for the
+     * dynamic table capacity. In HTTP/3, this limit is determined by
+     * the value of SETTINGS_QPACK_MAX_TABLE_CAPACITY sent by the
+     * decoder; see Section 5."
      */
     #[test]
     fn test_maximum_table_size_can_reach_maximum() {
@@ -608,7 +610,7 @@ mod tests {
     // Test duplicated fields
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-01#section-2.2
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-dynamic-table
      * "The dynamic table can contain duplicate entries (i.e., entries with
      *  the same name and same value).  Therefore, duplicate entries MUST NOT
      *  be treated as an error by a decoder."
@@ -643,7 +645,7 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-01#section-2.2
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-dynamic-table-capacity-and-
      * "Before a new entry is added to the dynamic table, entries are evicted
      *  from the end of the dynamic table until the size of the dynamic table
      *  is less than or equal to (maximum size - new entry size) or until the
@@ -669,10 +671,10 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-01#section-2.2
-     * "If the size of the new entry is less than or equal to the maximum
-     *  size, that entry is added to the table.  It is an error to attempt to
-     *  add an entry that is larger than the maximum size;"
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-dynamic-table-capacity-and-
+     * "It is an error if the encoder attempts to add an entry that is
+     * larger than the dynamic table capacity; the decoder MUST treat
+     * this as a connection error of type QPACK_ENCODER_STREAM_ERROR."
      */
     #[test]
     fn test_try_add_field_larger_than_maximum_size() {
@@ -693,7 +695,7 @@ mod tests {
     }
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-01#section-2.2
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-dynamic-table-capacity-and-
      * "This mechanism can be used to completely clear entries from the
      *  dynamic table by setting a maximum size of 0, which can subsequently
      *  be restored."

--- a/h3/src/qpack/static_.rs
+++ b/h3/src/qpack/static_.rs
@@ -314,7 +314,7 @@ mod tests {
     use super::*;
 
     /**
-     * https://tools.ietf.org/html/draft-ietf-quic-qpack-05
+     * https://www.rfc-editor.org/rfc/rfc9204.html#name-static-table
      *  3.1.  Static Table
      *  [...]
      *  Note the QPACK static table is indexed from 0, whereas the HPACK

--- a/h3/src/qpack/vas.rs
+++ b/h3/src/qpack/vas.rs
@@ -1,6 +1,7 @@
 /**
- * https://tools.ietf.org/html/draft-ietf-quic-qpack-01#section-2.2.1
- * https://tools.ietf.org/html/draft-ietf-quic-qpack-01#section-2.2.2
+ * https://www.rfc-editor.org/rfc/rfc9204.html#name-absolute-indexing
+ * https://www.rfc-editor.org/rfc/rfc9204.html#name-relative-indexing
+ * https://www.rfc-editor.org/rfc/rfc9204.html#name-post-base-indexing
  */
 
 /*

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -58,12 +58,17 @@ use crate::{
 };
 use tracing::{error, trace, warn};
 
-/// This function creates a [`Builder`] for the Server.
+/// Create a builder of HTTP/3 server connections
+///
+/// This function creates a [`Builder`] that carries settings that can
+/// be shared between server connections.
 pub fn builder() -> Builder {
     Builder::new()
 }
 
-/// The [`Connection`] struct manages a connection from the http/3 Server.
+/// Server connection driver
+///
+/// The [`Connection`] struct manages a connection from the side of the HTTP/3 server
 ///
 /// Create a new Instance with [`Connection::new()`].
 /// Accept incoming requests with [`Connection::accept()`].
@@ -97,8 +102,10 @@ where
     C: quic::Connection<B>,
     B: Buf,
 {
-    /// This method creates a new Connection for Servers with default settings.
-    /// Use [`builder()`] to create a connection with different settings.
+    /// Create a new HTTP/3 server connection with default settings
+    ///
+    /// Use a custom [`Builder`] with [`builder()`] to create a connection
+    /// with different settings.
     /// Provide a Connection which implements [`quic::Connection`].
     pub async fn new(conn: C) -> Result<Self, Error> {
         Ok(builder().build(conn).await?)
@@ -110,7 +117,8 @@ where
     C: quic::Connection<B>,
     B: Buf,
 {
-    /// This method accepts a http request from a Client.
+    /// Accept an incoming request.
+    ///
     /// It returns a tuple with a [`http::Request`] and an [`RequestStream`].
     /// The [`http::Request`] is the received request from the client.
     /// The [`RequestStream`] can be used to send the response.
@@ -307,8 +315,9 @@ where
         Ok(Some((req, request_stream)))
     }
 
-    /// This method stops the connection gracefully.
-    /// See [Connection-Shutdown](https://httpwg.org/specs/rfc9114.html#connection-shutdown) for more information.
+    /// Itiniate a graceful shutdown, accepting `max_request` potentially still in-flight
+    ///
+    /// See [connection shutdown](https://www.rfc-editor.org/rfc/rfc9114.html#connection-shutdown) for more information.
     pub async fn shutdown(&mut self, max_requests: usize) -> Result<(), Error> {
         self.inner.shutdown(max_requests).await
     }
@@ -454,8 +463,10 @@ where
 //# parallelism, at least 100 request streams SHOULD be permitted at a
 //# time.
 
+/// Builder of HTTP/3 server connections.
+///
 /// Use this struct to create a new [`Connection`].
-/// All the settings for the [`Connection`] can be provided here.
+/// Settings for the [`Connection`] can be provided here.
 ///
 /// # Example
 ///
@@ -487,9 +498,11 @@ impl Builder {
             send_grease: true,
         }
     }
-
-    /// Set the `max_field_section_size` for the [`Builder`].
-    /// See [Header size](https://httpwg.org/specs/rfc9114.html#header-size-constraints) for more information.
+    /// Set the maximum header size this client is willing to accept
+    ///
+    /// See [header size constraints] section of the specification for details.
+    ///
+    /// [header size constraints]: https://www.rfc-editor.org/rfc/rfc9114.html#name-header-size-constraints
     pub fn max_field_section_size(&mut self, value: u64) -> &mut Self {
         self.max_field_section_size = value;
         self
@@ -504,6 +517,8 @@ impl Builder {
 }
 
 impl Builder {
+    /// Build an HTTP/3 connection from a QUIC connection
+    ///
     /// This method creates a [`Connection`] instance with the settings in the [`Builder`].
     pub async fn build<C, B>(&self, conn: C) -> Result<Connection<C, B>, Error>
     where
@@ -527,12 +542,15 @@ impl Builder {
     }
 }
 
-pub struct RequestEnd {
+struct RequestEnd {
     request_end: mpsc::UnboundedSender<StreamId>,
     stream_id: StreamId,
 }
 
-/// The [`RequestStream`] struct is to send and/or receive information from the client.
+/// Manage request and response transfer for an incoming request
+///
+/// The [`RequestStream`] struct is used to send and/or receive
+/// information from the client.
 pub struct RequestStream<S, B> {
     inner: connection::RequestStream<S, B>,
     request_end: Arc<RequestEnd>,
@@ -554,11 +572,12 @@ impl<S, B> RequestStream<S, B>
 where
     S: quic::RecvStream,
 {
-    /// Receives data, sent from the Client.
+    /// Receive data sent from the client
     pub async fn recv_data(&mut self) -> Result<Option<impl Buf>, Error> {
         self.inner.recv_data().await
     }
 
+    /// Tell the peer to stop sending into the underlying QUIC stream
     pub fn stop_sending(&mut self, error_code: crate::error::Code) {
         self.inner.stream.stop_sending(error_code)
     }
@@ -569,7 +588,10 @@ where
     S: quic::SendStream<B>,
     B: Buf,
 {
-    /// This method sends a Http-Response to the Client.
+    /// Send the HTTP/3 response
+    ///
+    /// This should be called before trying to send any data with
+    /// [`RequestStream::send_data`].
     pub async fn send_response(&mut self, resp: Response<()>) -> Result<(), Error> {
         let (parts, _) = resp.into_parts();
         let response::Parts {
@@ -602,22 +624,32 @@ where
         Ok(())
     }
 
-    /// Send data to the Client.
+    /// Send some data on the response body.
     pub async fn send_data(&mut self, buf: B) -> Result<(), Error> {
         self.inner.send_data(buf).await
     }
 
-    /// Stops a stream with a error code
+    /// Stop a stream with an error code
+    ///
+    /// The code can be [`Code::H3_NO_ERROR`].
     pub fn stop_stream(&mut self, error_code: Code) {
         self.inner.stop_stream(error_code);
     }
 
-    /// Send the Http-Trailers.
+    /// Send a set of trailers to end the response.
+    ///
+    /// Either [`RequestStream::finish`] or
+    /// [`RequestStream::send_trailers`] must be called to finalize a
+    /// request.
     pub async fn send_trailers(&mut self, trailers: HeaderMap) -> Result<(), Error> {
         self.inner.send_trailers(trailers).await
     }
 
-    // Closes the Stream when all data is sent.
+    /// End the response without trailers.
+    ///
+    /// Either [`RequestStream::finish`] or
+    /// [`RequestStream::send_trailers`] must be called to finalize a
+    /// request.
     pub async fn finish(&mut self) -> Result<(), Error> {
         self.inner.finish().await
     }
@@ -628,7 +660,7 @@ where
     S: quic::RecvStream + quic::SendStream<B>,
     B: Buf,
 {
-    /// Receives Http-Trailers from the Client.
+    /// Receive an optional set of trailers for the request.
     pub async fn recv_trailers(&mut self) -> Result<Option<HeaderMap>, Error> {
         let res = self.inner.recv_trailers().await;
         if let Err(ref e) = res {

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -509,7 +509,7 @@ impl Builder {
     }
 
     /// Send grease values to the Client.
-    /// See [setting](https://httpwg.org/specs/rfc9114.html#settings-parameters), [frame](https://httpwg.org/specs/rfc9114.html#frame-reserved) and [stream](https://httpwg.org/specs/rfc9114.html#stream-grease) for more information.
+    /// See [setting](https://www.rfc-editor.org/rfc/rfc9114.html#settings-parameters), [frame](https://www.rfc-editor.org/rfc/rfc9114.html#frame-reserved) and [stream](https://www.rfc-editor.org/rfc/rfc9114.html#stream-grease) for more information.
     pub fn send_grease(&mut self, value: bool) -> &mut Self {
         self.send_grease = value;
         self


### PR DESCRIPTION
This is an updated and rebased version of #82.

I couldn't turn on `#![deny(missing_docs)]` for the whole crate because the `test_helpers` feature exposes about 138 undocumented qpack and proto functions.

Refactoring the tests to be part of the original crate would fix that (and remove the need to backdoor module privacy).  I added the `#[deny(missing_docs)]` attribute to the rest of the modules instead.

Also updated draft references to point to published RFCs.

Motivation for the pull request is that I would like a preliminary release of the crate; see #125, and #70 before that.
