### PR TITLE
generate a sslkeylogfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,6 @@ As mentioned, the goal of this library is to be generic over a QUIC implementati
 This crate as well as the quic implementations are tested ([quinn](https://github.com/quinn-rs/quinn-interop), [s2n-quic](https://github.com/aws/s2n-quic/tree/main/scripts/interop)) for interoperability and performance in the [quic-interop-runner](https://github.com/marten-seemann/quic-interop-runner).
 You can see the results at (https://interop.seemann.io/).
 
-## Debugging
-The example [example client](https://github.com/hyperium/h3/examples/client.rs) can generate a `SSLKEYLOGFILE` to see the traffic unencrypted in tools like Wireshark.  
-To set this up just set the `SSLKEYLOGFILE` environment variable to a file path and follow this [tutorial](https://wiki.wireshark.org/TLS#using-the-pre-master-secret).
-Then use the example client with the `--keylogfile=true` option to enable this.
-
-
 ## License
 
 h3 is provided under the MIT license. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ You can see the results at (https://interop.seemann.io/).
 
 ## Debugging
 The example [example client](https://github.com/hyperium/h3/examples/client.rs) can generate a `SSLKEYLOGFILE` to see the traffic unencrypted in tools like Wireshark.  
-To set this up just set the `SSLKEYLOGFILE` environment variable to a file path and follow this [tutorial](https://wiki.wireshark.org/TLS#using-the-pre-master-secret)
+To set this up just set the `SSLKEYLOGFILE` environment variable to a file path and follow this [tutorial](https://wiki.wireshark.org/TLS#using-the-pre-master-secret).
+Then use the example client with the `--keylogfile=true` option to enable this.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ As mentioned, the goal of this library is to be generic over a QUIC implementati
 This crate as well as the quic implementations are tested ([quinn](https://github.com/quinn-rs/quinn-interop), [s2n-quic](https://github.com/aws/s2n-quic/tree/main/scripts/interop)) for interoperability and performance in the [quic-interop-runner](https://github.com/marten-seemann/quic-interop-runner).
 You can see the results at (https://interop.seemann.io/).
 
+## Debugging
+The example [example client](https://github.com/hyperium/h3/examples/client.rs) can generate a `SSLKEYLOGFILE` to see the traffic unencrypted in tools like Wireshark.  
+To set this up just set the `SSLKEYLOGFILE` environment variable to a file path and follow this [tutorial](https://wiki.wireshark.org/TLS#using-the-pre-master-secret)
+
+
 ## License
 
 h3 is provided under the MIT license. See [LICENSE](LICENSE).

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -18,6 +18,9 @@ struct Opt {
     #[structopt(long)]
     pub insecure: bool,
 
+    #[structopt(name = "keylogfile", long)]
+    pub key_log_file: bool,
+
     #[structopt()]
     pub uri: String,
 }
@@ -83,8 +86,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tls_config.enable_early_data = true;
     tls_config.alpn_protocols = vec![ALPN.into()];
 
-    // Write all Keys to a file if SSLKEYLOGFILE is set
-    tls_config.key_log = Arc::new(rustls::KeyLogFile::new());
+    if opt.key_log_file {
+        // Write all Keys to a file if SSLKEYLOGFILE is set
+        // WARNING, we enable this for the example, you should think carefully about enabling in your own code
+        tls_config.key_log = Arc::new(rustls::KeyLogFile::new());
+    }
+
     let client_config = quinn::ClientConfig::new(Arc::new(tls_config));
 
     let mut client_endpoint = h3_quinn::quinn::Endpoint::client("[::]:0".parse().unwrap())?;

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -82,6 +82,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     tls_config.enable_early_data = true;
     tls_config.alpn_protocols = vec![ALPN.into()];
+
+    // Write all Keys to a file if SSLKEYLOGFILE is set
+    tls_config.key_log = Arc::new(rustls::KeyLogFile::new());
     let client_config = quinn::ClientConfig::new(Arc::new(tls_config));
 
     let mut client_endpoint = h3_quinn::quinn::Endpoint::client("[::]:0".parse().unwrap())?;

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -49,3 +49,8 @@ Then run chromium and force it to use Quic.
 ```
 
 Now you can navigate to files in the `root` folder for example `https://localhost:4433/index.html`.
+
+## Debugging
+The example [example client](https://github.com/hyperium/h3/examples/client.rs) can generate a `SSLKEYLOGFILE` to see the traffic unencrypted in tools like Wireshark.  
+To set this up just set the `SSLKEYLOGFILE` environment variable to a file path and follow this [tutorial](https://wiki.wireshark.org/TLS#using-the-pre-master-secret).
+Then use the example client with the `--keylogfile=true` option to enable this.


### PR DESCRIPTION
I changed the default tls settings in the example client to generate a `sslkeylogfile` if the `SSLKEYLOGFILE` environment variable is set.
This can help to understand the http/3 protocol or to debug.