### PR TITLE
Fix clippy warnings

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -137,7 +137,7 @@ where
         None => (StatusCode::OK, None),
         Some(_) if req.uri().path().contains("..") => (StatusCode::NOT_FOUND, None),
         Some(root) => {
-            let to_serve = root.join(req.uri().path().strip_prefix("/").unwrap_or(""));
+            let to_serve = root.join(req.uri().path().strip_prefix('/').unwrap_or(""));
             match File::open(&to_serve).await {
                 Ok(file) => (StatusCode::OK, Some(file)),
                 Err(e) => {

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -489,12 +489,12 @@ impl From<WriteError> for SendStreamError {
 
 impl Error for SendStreamError {
     fn is_timeout(&self) -> bool {
-        match self {
-            Self::Write(quinn::WriteError::ConnectionLost(quinn::ConnectionError::TimedOut)) => {
-                true
-            }
-            _ => false,
-        }
+        matches!(
+            self,
+            Self::Write(quinn::WriteError::ConnectionLost(
+                quinn::ConnectionError::TimedOut
+            ))
+        )
     }
 
     fn err_code(&self) -> Option<u64> {

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -483,7 +483,7 @@ where
         {
             Err(err) => {
                 warn!("grease stream creation failed with {}", err);
-                return ();
+                return;
             }
             Ok(grease) => grease,
         };
@@ -495,10 +495,10 @@ where
         //# sent when application-layer padding is desired.  They MAY also be
         //# sent on connections where no data is currently being transferred.
         match stream::write(&mut grease_stream, (StreamType::grease(), Frame::Grease)).await {
-            Ok(_) => (),
+            Ok(()) => (),
             Err(err) => {
                 warn!("write data on grease stream failed with {}", err);
-                return ();
+                return;
             }
         }
 
@@ -514,13 +514,9 @@ where
             .await
             .map_err(|e| Code::H3_NO_ERROR.with_transport(e))
         {
-            Err(err) => {
-                warn!("grease stream error on close {}", err);
-                return ();
-            }
-            Ok(_) => (),
-        }
-        ()
+            Ok(()) => (),
+            Err(err) => warn!("grease stream error on close {}", err),
+        };
     }
 }
 

--- a/h3/src/lib.rs
+++ b/h3/src/lib.rs
@@ -1,5 +1,6 @@
 //! HTTP/3 client and server
-#![deny(missing_docs)]
+#![deny(missing_docs, clippy::self_named_module_files)]
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 pub mod client;
 pub mod error;

--- a/h3/src/qpack/dynamic.rs
+++ b/h3/src/qpack/dynamic.rs
@@ -533,6 +533,8 @@ impl From<vas::Error> for Error {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::identity_op)]
+
     use super::*;
     use crate::qpack::{static_::StaticTable, tests::helpers::build_table};
 
@@ -1036,7 +1038,7 @@ mod tests {
         }
 
         for idx in 1..4 {
-            assert_eq!(table.is_tracked(idx), true);
+            assert!(table.is_tracked(idx));
             assert_eq!(table.track_map.get(&1), Some(&1));
         }
         let track_blocks = table.track_blocks;

--- a/h3/src/qpack/encoder.rs
+++ b/h3/src/qpack/encoder.rs
@@ -298,6 +298,7 @@ mod tests {
 
     use crate::qpack::tests::helpers::{build_table, TABLE_SIZE};
 
+    #[allow(clippy::type_complexity)]
     fn check_encode_field(
         init_fields: &[HeaderField],
         field: &[HeaderField],
@@ -308,6 +309,7 @@ mod tests {
         check_encode_field_table(&mut table, init_fields, field, 1, check);
     }
 
+    #[allow(clippy::type_complexity)]
     fn check_encode_field_table(
         table: &mut DynamicTable,
         init_fields: &[HeaderField],

--- a/h3/src/qpack/prefix_string/decode.rs
+++ b/h3/src/qpack/prefix_string/decode.rs
@@ -326,6 +326,8 @@ impl HpackStringDecode for Vec<u8> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::identity_op)]
+
     use super::*;
 
     #[test]

--- a/h3/src/qpack/prefix_string/encode.rs
+++ b/h3/src/qpack/prefix_string/encode.rs
@@ -398,15 +398,19 @@ impl HpackStringEncode for Vec<u8> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::identity_op)]
+
     use super::*;
 
     #[test]
     fn test_set_bits() {
         let mut buf = [0b1111_1111; 16];
-        let mut pos = BitWindow::default();
-
         // Write a full 8 bits into a single byte
-        pos.count = 8;
+        let mut pos = BitWindow {
+            count: 8,
+            ..Default::default()
+        };
+
         write_bits(&mut buf, &pos, 0b1_0101);
         assert_eq!(&buf[..1], &[0b1_0101]);
         pos.byte += 1;

--- a/h3/src/qpack/prefix_string/mod.rs
+++ b/h3/src/qpack/prefix_string/mod.rs
@@ -123,7 +123,7 @@ mod tests {
         let mut read = Cursor::new(&buf);
         assert_eq!(
             &buf,
-            &[0b100_01010, 168, 116, 149, 79, 6, 76, 234, 88, 89, 127]
+            &[0b1000_1010, 168, 116, 149, 79, 6, 76, 234, 88, 89, 127]
         );
         assert_eq!(decode(8, &mut read).unwrap(), b"name with ref");
     }
@@ -133,7 +133,7 @@ mod tests {
         let mut buf = Vec::new();
         encode(8, 0b01, b"", &mut buf).unwrap();
         let mut read = Cursor::new(&buf);
-        assert_eq!(&buf, &[0b100_00000]);
+        assert_eq!(&buf, &[0b1000_0000]);
         assert_eq!(decode(8, &mut read).unwrap(), b"");
     }
 

--- a/h3/src/qpack/vas.rs
+++ b/h3/src/qpack/vas.rs
@@ -275,16 +275,16 @@ mod tests {
     #[test]
     fn evicted() {
         let mut vas = VirtualAddressSpace::default();
-        assert_eq!(vas.evicted(0), false);
-        assert_eq!(vas.evicted(1), false);
+        assert!(!vas.evicted(0));
+        assert!(!vas.evicted(1));
         vas.add();
         vas.add();
-        assert_eq!(vas.evicted(1), false);
+        assert!(!vas.evicted(1));
         vas.drop();
-        assert_eq!(vas.evicted(0), false);
-        assert_eq!(vas.evicted(1), true);
-        assert_eq!(vas.evicted(2), false);
+        assert!(!vas.evicted(0));
+        assert!(vas.evicted(1));
+        assert!(!vas.evicted(2));
         vas.drop();
-        assert_eq!(vas.evicted(2), true);
+        assert!(vas.evicted(2));
     }
 }

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -124,7 +124,7 @@ where
     /// with different settings.
     /// Provide a Connection which implements [`quic::Connection`].
     pub async fn new(conn: C) -> Result<Self, Error> {
-        Ok(builder().build(conn).await?)
+        builder().build(conn).await
     }
 }
 
@@ -160,7 +160,7 @@ where
                     } => {
                         return Err(self.inner.close(
                             code,
-                            reason.unwrap_or(String::into_boxed_str(String::from(""))),
+                            reason.unwrap_or_else(|| String::into_boxed_str(String::from(""))),
                         ))
                     }
                     _ => return Err(err),
@@ -217,7 +217,7 @@ where
                     } => {
                         return Err(self.inner.close(
                             code,
-                            reason.unwrap_or(String::into_boxed_str(String::from(""))),
+                            reason.unwrap_or_else(|| String::into_boxed_str(String::from(""))),
                         ))
                     }
                     crate::error::Kind::Application {
@@ -280,7 +280,7 @@ where
                         } => {
                             return Err(self.inner.close(
                                 code,
-                                reason.unwrap_or(String::into_boxed_str(String::from(""))),
+                                reason.unwrap_or_else(|| String::into_boxed_str(String::from(""))),
                             ))
                         }
                         crate::error::Kind::Application {

--- a/h3/src/tests/connection.rs
+++ b/h3/src/tests/connection.rs
@@ -1,3 +1,6 @@
+// identity_op: we write out how test values are computed
+#![allow(clippy::identity_op)]
+
 use std::{borrow::BorrowMut, time::Duration};
 
 use assert_matches::assert_matches;
@@ -655,7 +658,7 @@ async fn graceful_shutdown_closes_when_idle() {
         let (mut driver, mut send_request) = client::new(pair.client().await).await.unwrap();
 
         // Make continuous requests, ignoring GoAway because the connection is not driven
-        while let Ok(_) = request(&mut send_request).await {
+        while request(&mut send_request).await.is_ok() {
             tokio::task::yield_now().await;
         }
         assert_matches!(
@@ -675,10 +678,8 @@ async fn graceful_shutdown_closes_when_idle() {
         let mut count = 0;
 
         while let Ok(Some((_, stream))) = incoming.accept().await {
-            if count < 3 {
-                count += 1;
-            } else if count == 3 {
-                count += 1;
+            count += 1;
+            if count == 4 {
                 incoming.shutdown(2).await.unwrap();
             }
 


### PR DESCRIPTION
Also enforce mod.rs module style, and allow PartialEq without Eq due to this: https://github.com/rust-lang/rust-clippy/issues/9063