### PR TITLE
Improve compliance ci action

### DIFF
--- a/.github/actions/compliance/action.yml
+++ b/.github/actions/compliance/action.yml
@@ -1,37 +1,46 @@
-name: 'Spec compliance'
-description: 'Use Duvet to generate spec compliance report'
+name: 'Spec compliance report'
+description: 'Generate compliance report and publish on Github pages'
 
 inputs:
   extract-script:
-    description: 'Path to script that extracts compliance checks'
+    description: 'Path to script that extracts compliance requirements'
     required: true
   report-script:
-    description: 'Path to script that generates a Duvet report'
+    description: 'Path to script that generates a compliance report'
     required: true
-  dir:
+  h3-dir:
     description: 'Path to the directory where h3 is cloned'
-    default: ${{ github.workspace }}
     required: false
+    default: ${{ github.workspace }}
 
 runs:
   using: "composite"
   steps:
-    - uses: actions-rs/toolchain@v1.0.7
-      id: toolchain
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         override: true
 
-    - uses: camshaft/rust-cache@v1
+    - name: Cache builds
+      uses: camshaft/rust-cache@v1
 
-    - uses: camshaft/install@v1
+    - name: Install Duvet w/ caching
+      uses: camshaft/install@v1
       with:
         crate: duvet
 
-    - name: Checkout gh-pages
+    - name: Set variables
+      shell: bash
       run: |
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        echo "SHA=`git rev-parse --short HEAD`" >> $GITHUB_ENV
+
+    # create gh-pages as an orphan branch if branch does not exist
+    - name: Checkout gh-pages
+      shell: bash
+      run: |
         git config --local user.name "github-actions[bot]"
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
         if git ls-remote --exit-code --heads origin gh-pages; then
           cp -r .github ci h3 target
@@ -41,23 +50,24 @@ runs:
           git checkout --orphan gh-pages
           git reset
         fi
-      shell: bash
 
-    - name: Generate duvet report
-      working-directory: ${{ inputs.dir }}
+    - name: Generate report
+      working-directory: ${{ inputs.h3-dir }}
+      shell: bash
       run: |
         ${{ inputs.extract-script }}
-        ${{ inputs.report-script }} ${{ github.sha }}
-      shell: bash
+        ${{ inputs.report-script }} $SHA
 
-    - name: Commit
-      working-directory: ${{ inputs.dir }}
+    # commit only when there are changes
+    - name: Commit report changes
+      working-directory: ${{ inputs.h3-dir }}
+      shell: bash
       run: |
         git add ci/compliance/*.html
         git diff --staged --quiet || \
-        git commit -m "${{ github.triggering_actor }}-${{ github.sha }}-${{ github.job }}#${{ github.run_number }}"
-      shell: bash
+        git commit -m "${{ github.triggering_actor }}-${SHA}-${{ github.job }}#${{ github.run_number }}"
 
+    # publish report only when pushing to master
     - name: Push to gh-pages
       if: github.ref == 'refs/heads/master'
       uses: ad-m/github-push-action@master

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -178,16 +178,15 @@ jobs:
           args: fuzz run fuzz_varint -- -runs=1
 
   compliance:
-    name: Check spec compliance
+    name: Compliance report
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Generate report
+      - name: Generate compliance report
         uses: ./.github/actions/compliance
         with:
           extract-script: ${{ github.workspace }}/ci/compliance/extract.sh

--- a/ci/compliance/extract.sh
+++ b/ci/compliance/extract.sh
@@ -2,11 +2,17 @@
 
 set -e
 
-duvet \
-    extract \
-    https://www.rfc-editor.org/rfc/rfc9114 \
-    --format "IETF" \
-    --out "." \
-    --extension "toml"
+specs=(
+    'https://www.rfc-editor.org/rfc/rfc9114'
+)
 
-echo "compliance checks available in 'specs/www.rfc-editor.org/rfc/rfc9114/'"
+for spec in "${specs[@]}"
+do
+    duvet extract \
+        $spec \
+        --format 'IETF' \
+        --out '.' \
+        --extension 'toml'
+done
+
+echo "compliance checks available in 'specs/'"

--- a/ci/compliance/report.sh
+++ b/ci/compliance/report.sh
@@ -4,17 +4,16 @@ set -e
 
 BLOB=${1:-master}
 
-duvet \
-  report \
-  --spec-pattern 'specs/**/*.toml' \
-  --spec-pattern 'ci/compliance/specs/**/*.toml' \
-  --source-pattern 'h3/**/*.rs' \
-  --workspace \
-  --exclude duvet \
-  --require-tests false \
-  --blob-link "https://github.com/hyperium/h3/blob/$BLOB" \
-  --issue-link 'https://github.com/hyperium/h3/issues' \
-  --no-cargo \
-  --html ci/compliance/report.html
+duvet report \
+    --spec-pattern 'specs/**/*.toml' \
+    --spec-pattern 'ci/compliance/specs/**/*.toml' \
+    --source-pattern 'h3/**/*.rs' \
+    --workspace \
+    --exclude duvet \
+    --require-tests false \
+    --blob-link "https://github.com/hyperium/h3/blob/$BLOB" \
+    --issue-link 'https://github.com/hyperium/h3/issues' \
+    --no-cargo \
+    --html ci/compliance/report.html
 
 echo "compliance report available in 'ci/compliance/report.html'"


### PR DESCRIPTION
* prep extraction script for multi-spec report
* use short hash for commit msgs
* clarify stuff a bit

Right now every push to master triggers a push to gh-pages even if the compliance status doesn't change, because the report generation isn't deterministic. Already fixed in duvet, (hopefully) the problem will auto resolve once the patches are released.