### PR TITLE
No more repetitive reports

### DIFF
--- a/.github/actions/compliance/action.yml
+++ b/.github/actions/compliance/action.yml
@@ -56,7 +56,7 @@ runs:
       shell: bash
       run: |
         ${{ inputs.extract-script }}
-        ${{ inputs.report-script }} $SHA
+        ${{ inputs.report-script }}
 
     # commit only when there are changes
     - name: Commit report changes

--- a/ci/compliance/report.sh
+++ b/ci/compliance/report.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-BLOB=${1:-master}
-
 duvet report \
     --spec-pattern 'specs/**/*.toml' \
     --spec-pattern 'ci/compliance/specs/**/*.toml' \
@@ -11,7 +9,7 @@ duvet report \
     --workspace \
     --exclude duvet \
     --require-tests false \
-    --blob-link "https://github.com/hyperium/h3/blob/$BLOB" \
+    --blob-link "https://github.com/hyperium/h3/blob/master" \
     --issue-link 'https://github.com/hyperium/h3/issues' \
     --no-cargo \
     --html ci/compliance/report.html


### PR DESCRIPTION
I could confirm that this patch fixes the problem on another fork.

<img width="372" alt="image" src="https://user-images.githubusercontent.com/64203473/194772136-d92003d4-da39-45e9-ad99-2280a71b24e3.png">

This isn't ideal as source links in future reports may not always link to the right spot. But the latest report is alright. I guess this wouldn't be too much of a problem as we basically only care about the latest one.