### PR TITLE
don't try to handle header-too-big error when receiving trailers

### DIFF
--- a/h3/src/tests/connection.rs
+++ b/h3/src/tests/connection.rs
@@ -334,7 +334,7 @@ async fn control_close_send_error() {
         let mut incoming = server::Connection::new(conn).await.unwrap();
         // Driver detects that the recieving side of the control stream has been closed
         assert_matches!(
-        incoming.accept().await.map(|_| ()).unwrap_err().kind(),
+            incoming.accept().await.map(|_| ()).unwrap_err().kind(),
             Kind::Application { reason: Some(reason), code: Code::H3_CLOSED_CRITICAL_STREAM, .. }
             if *reason == *"control stream closed");
         // Poll it once again returns the previously stored error

--- a/h3/src/tests/request.rs
+++ b/h3/src/tests/request.rs
@@ -330,12 +330,6 @@ async fn header_too_big_response_from_server_trailers() {
                 .await
                 .expect("send trailers");
             request_stream.finish().await.expect("client finish");
-
-            let response = request_stream.recv_response().await.unwrap();
-            assert_eq!(
-                response.status(),
-                StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE
-            );
         };
         tokio::select! {biased; _ = req_fut => (), _ = drive_fut => () }
     };


### PR DESCRIPTION
closes #140 