### PR TITLE
CI overhaul

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,9 +9,9 @@ env:
   RUST_BACKTRACE: 1
   toolchain_style: stable
   toolchain_msrv: 1.56
-  toolchain_doc: nightly-2022-11-03
+  toolchain_doc: nightly-2022-12-01
   toolchain_lint: stable
-  toolchain_fuzz: nightly-2022-11-03
+  toolchain_fuzz: nightly-2022-12-01
 
 jobs:
   ci-pass:
@@ -141,15 +141,14 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-fuzz
-        uses: actions-rs/cargo@v1
+        uses: camshaft/install@v1
         with:
-          command: install
-          args: cargo-fuzz
+          crate: cargo-fuzz
       - name: cargo fuzz run fuzz_varint -- -runs=1
         uses: actions-rs/cargo@v1
         with:
-          command: +nightly
-          args: fuzz run fuzz_varint -- -runs=1
+          command: fuzz
+          args: run fuzz_varint -- -runs=1
 
   compliance:
     name: Compliance report


### PR DESCRIPTION
closes #154 

* remove nightly tests to unblock stuff
* nuke `build` job
* cargo check MSRV
* pin to nightly-2022-12-01
* cache builds (esp. cargo-fuzz) to speed things up