### PR TITLE
Replace endpoint builders with config builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
 # h3
 
-An async HTTP/3 implementation.
-
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/hyperium/h3/workflows/CI/badge.svg)](https://github.com/hyperium/h3/actions?query=workflow%3ACI)
 [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord)](https://discord.gg/q5mVhMD)
 
-This crate provides an [HTTP/3][spec] implementation that is generic over a provided QUIC transport. This allows the project to focus on just HTTP/3, while letting users pick their QUIC implementation based on their specific needs. It includes client and server APIs. Check the original [design][] for more details.
+An async HTTP/3 implementation.
+
+This crate provides an [HTTP/3][spec] implementation that is generic over a provided QUIC transport. This allows the project to focus on just HTTP/3, while letting users pick their QUIC implementation based on their specific needs. Check the original [design][] for more details.
+
+Features
+
+* async API
+* **[`h3`](./h3)** HTTP/3 client and server implementation
+* **[`quic`](./h3/src/quic.rs)** contains traits for abstracting QUIC implementations
+* **[`h3-quinn`](./h3-quinn)** integration support for Quinn
+
+As mentioned, the goal of this library is to be generic over a QUIC implementation. To that effect, integrations with QUIC libraries exist:
+
+- [`h3-quinn`](./h3-quinn/)
+- [`s2n-quic-h3`](https://github.com/aws/s2n-quic/tree/main/quic/s2n-quic-h3)
 
 [spec]: https://www.rfc-editor.org/rfc/rfc9114
 [design]: design/PROPOSAL.md
@@ -19,6 +31,13 @@ The eventual goal is to use `h3` as an internal dependency of [hyper][].
 
 [hyper]: https://hyper.rs
 
+## Getting Started
+
+The [examples](./examples) directory can help get started in two ways:
+
+- There are ready-to-use `client` and `server` binaries to interact with _other_ HTTP/3 peers. Check the README in that directory.
+- The source code of those examples can help teach how to use `h3` as either a client or a server.
+
 ### Duvet
 This create uses the [duvet crate][] to check compliance of the [spec][].  
 The generated [report][] displays the current status of the requirements of the spec.  
@@ -29,105 +48,6 @@ Get more information about this tool in the [contributing][] document.
 [spec]: https://www.rfc-editor.org/rfc/rfc9114
 [report]: https://hyper.rs/h3/ci/compliance/report.html#/
 [contributing]: CONTRIBUTING.md
-
-## Features
-
-* HTTP/3 client and server implementation
-* Async only API
-* QUIC transport abstraction via traits in the [`quic`](./h3/src/quic.rs) module
-* Supported QUIC implementations to date are
-  [Quinn](https://github.com/quinn-rs/quinn) ([h3-quinn](./h3-quinn/))
-  and [s2n-quic](https://github.com/aws/s2n-quic)
-  ([s2n-quic-h3](https://github.com/aws/s2n-quic/tree/main/quic/s2n-quic-h3))
-
-## Overview
-
-* **h3** HTTP/3 implementation
-* **h3-quinn** QUIC transport implementation based on [Quinn](https://github.com/quinn-rs/quinn/)
-
-## Getting Started
-
-The [examples](./examples) directory can help get started in two ways:
-
-- There are ready-to-use `client` and `server` binaries to interact with _other_ HTTP/3 peers. Check the README in that directory.
-- The source code of those examples can help teach how to use `h3` as either a client or a server.
-
-### Server
-
-```rust
-let (endpoint, mut incoming) = h3_quinn::quinn::Endpoint::server(server_config, "[::]:443".parse()?)?;
-
-while let Some((req, stream)) = h3_conn.accept().await? {
-    loop {
-        match h3_conn.accept().await {
-            Ok(Some((req, mut stream))) => {
-                let resp = http::Response::builder().status(Status::OK).body(())?;
-                stream.send_response(resp).await?;
-
-                stream.send_data(Bytes::new("It works!")).await?;
-                stream.finish().await?;
-            }
-            Ok(None) => {
-                 break;
-            }
-            Err(err) => {
-                match err.get_error_level() {
-                    ErrorLevel::ConnectionError => break,
-                    ErrorLevel::StreamError => continue,
-                }
-            }
-        }
-    }
-}
-endpoint.wait_idle();
-```
-
-You can find a full server example in [`examples/server.rs`](./examples/server.rs)
-
-### Client
-
-``` rust
-let addr: SocketAddr = "[::1]:443".parse()?;
-
-let quic = h3_quinn::Connection::new(client_endpoint.connect(addr, "server")?.await?);
-let (mut driver, mut send_request) = h3::client::new(quinn_conn).await?;
-
-let drive = async move {
-    future::poll_fn(|cx| driver.poll_close(cx)).await?;
-    Ok::<(), Box<dyn std::error::Error>>(())
-};
-
-let request = async move {
-    let req = http::Request::builder().uri(dest).body(())?;
-
-    let mut stream = send_request.send_request(req).await?;
-    stream.finish().await?;
-
-    let resp = stream.recv_response().await?;
-
-    while let Some(mut chunk) = stream.recv_data().await? {
-        let mut out = tokio::io::stdout();
-        out.write_all_buf(&mut chunk).await?;
-        out.flush().await?;
-    }
-    Ok::<_, Box<dyn std::error::Error>>(())
-};
-
-let (req_res, drive_res) = tokio::join!(request, drive);
-req_res?;
-drive_res?;
-
-client_endpoint.wait_idle().await;
-```
-
-You can find a full client example in [`examples/client.rs`](./examples/client.rs)
-
-## QUIC Generic
-
-As mentioned, the goal of this library is to be generic over a QUIC implementation. To that effect, integrations with QUIC libraries exist:
-
-- [`h3-quinn`](./h3-quinn/): in this same repository.
-- [`s2n-quic-h3`](https://github.com/aws/s2n-quic/tree/main/quic/s2n-quic-h3)
 
 ## Interoperability
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -113,7 +113,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // h3_quinn implements the trait w/ quinn to make it work with h3.
     let quinn_conn = h3_quinn::Connection::new(conn);
 
-    let (mut driver, mut send_request) = h3::client::new(quinn_conn).await?;
+    let (mut driver, mut send_request) = h3::client::new(quinn_conn, Default::default()).await?;
 
     let drive = async move {
         future::poll_fn(|cx| driver.poll_close(cx)).await?;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -116,10 +116,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Ok(conn) => {
                     info!("new connection established");
 
-                    let mut h3_conn = h3::server::Connection::new(h3_quinn::Connection::new(conn))
-                        .await
-                        .unwrap();
-
+                    let mut h3_conn = h3::server::Connection::new(
+                        h3_quinn::Connection::new(conn),
+                        Default::default(),
+                    )
+                    .await
+                    .unwrap();
                     loop {
                         match h3_conn.accept().await {
                             Ok(Some((req, stream))) => {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -116,12 +116,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Ok(conn) => {
                     info!("new connection established");
 
-                    let mut h3_conn = h3::server::Connection::new(
-                        h3_quinn::Connection::new(conn),
-                        Default::default(),
-                    )
-                    .await
-                    .unwrap();
+                    let mut h3_conn =
+                        h3::server::new(h3_quinn::Connection::new(conn), Default::default())
+                            .await
+                            .unwrap();
                     loop {
                         match h3_conn.accept().await {
                             Ok(Some((req, stream))) => {

--- a/h3/src/config.rs
+++ b/h3/src/config.rs
@@ -1,0 +1,70 @@
+//! HTTP/3 endpoint config
+
+/// Default max header size
+pub const DEFAULT_MAX_FIELD_SECTION_SIZE: u64 = (1 << 62) - 1;
+
+/// Client config builder
+#[derive(Debug, Default)]
+pub struct ClientConfig {
+    pub(crate) conn: ConnectionConfig,
+}
+
+/// Server config builder
+#[derive(Debug, Default)]
+pub struct ServerConfig {
+    pub(crate) conn: ConnectionConfig,
+}
+
+/// Configuration for [`ConnectionInner`]
+#[derive(Clone, Copy, Debug)]
+pub struct ConnectionConfig {
+    pub(crate) enable_grease: bool,
+    pub(crate) enable_webtransport: bool,
+    pub(crate) max_field_section_size: u64,
+}
+
+impl Default for ConnectionConfig {
+    fn default() -> Self {
+        Self {
+            enable_grease: true,
+            enable_webtransport: false,
+            max_field_section_size: DEFAULT_MAX_FIELD_SECTION_SIZE,
+        }
+    }
+}
+
+macro_rules! impl_builder {
+    ($name:ident) => {
+        impl $name {
+            /// Start to build config
+            pub fn new() -> Self {
+                Self::default()
+            }
+
+            /// Disable grease in SETTINGS
+            pub fn disable_grease(mut self) -> Self {
+                self.conn.enable_grease = false;
+                self
+            }
+
+            /// Enable WebTransport
+            pub fn enable_webtransport(mut self) -> Self {
+                self.conn.enable_webtransport = true;
+                self
+            }
+
+            /// Set maximum header size the endpoint is willing to accept
+            ///
+            /// See [header size constraints] section of the specification for details.
+            ///
+            /// [header size constraints]: https://www.rfc-editor.org/rfc/rfc9114.html#name-header-size-constraints
+            pub fn max_field_section_size(mut self, val: u64) -> Self {
+                self.conn.max_field_section_size = val;
+                self
+            }
+        }
+    };
+}
+
+impl_builder!(ClientConfig);
+impl_builder!(ServerConfig);

--- a/h3/src/config.rs
+++ b/h3/src/config.rs
@@ -47,7 +47,7 @@ macro_rules! impl_builder {
                 self
             }
 
-            /// Enable WebTransport
+            /// Enable WebTransport (not supported yet)
             pub fn enable_webtransport(mut self) -> Self {
                 self.conn.enable_webtransport = true;
                 self

--- a/h3/src/lib.rs
+++ b/h3/src/lib.rs
@@ -3,10 +3,12 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 pub mod client;
+pub mod config;
 pub mod error;
 pub mod quic;
 pub mod server;
 
+pub use config::{ClientConfig, ServerConfig};
 pub use error::Error;
 
 mod buf;

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -11,9 +11,8 @@
 //! C: h3::quic::Connection<bytes::Bytes>,
 //! <C as h3::quic::Connection<bytes::Bytes>>::BidiStream: Send + 'static
 //! {
-//!     let mut server_builder = h3::server::builder();
-//!     // Build the Connection
-//!     let mut h3_conn = server_builder.build(conn).await.unwrap();
+//!     let mut h3_conn = h3::server::new(conn, Default::default()).await.unwrap();
+//!
 //!     loop {
 //!         // Accept incoming requests
 //!         match h3_conn.accept().await {
@@ -62,24 +61,45 @@ use futures_util::future;
 use http::{response, HeaderMap, Request, Response, StatusCode};
 use quic::StreamId;
 use tokio::sync::mpsc;
+use tracing::{error, trace, warn};
 
 use crate::{
+    config::ServerConfig,
     connection::{self, ConnectionInner, ConnectionState, SharedStateRef},
     error::{Code, Error, ErrorLevel},
     frame::FrameStream,
-    proto::{frame::Frame, headers::Header, varint::VarInt},
+    proto::{frame::Frame, headers::Header},
     qpack,
     quic::{self, RecvStream as _, SendStream as _},
     stream,
 };
-use tracing::{error, trace, warn};
 
-/// Create a builder of HTTP/3 server connections
+/// Create an HTTP/3 server endpoint [`Connection`] with
+/// a QUIC connection endpoint and
+/// the configuration for the HTTP/3 server endpoint.
 ///
-/// This function creates a [`Builder`] that carries settings that can
-/// be shared between server connections.
-pub fn builder() -> Builder {
-    Builder::new()
+/// # Example
+///
+/// ```rust
+/// async fn doc<C, B>(conn: C)
+/// where
+/// C: h3::quic::Connection<B>,
+/// B: bytes::Buf,
+/// {
+///     let config = h3::ServerConfig::new()
+///         .disable_grease()
+///         .enable_webtransport()
+///         .max_field_section_size(8192);
+///
+///     let server = h3::server::new(conn, config).await.unwrap();
+/// }
+/// ```
+pub async fn new<C, B>(conn: C, config: ServerConfig) -> Result<Connection<C, B>, Error>
+where
+    C: quic::Connection<B>,
+    B: Buf,
+{
+    Connection::new(conn, config).await
 }
 
 /// Server connection driver
@@ -118,13 +138,25 @@ where
     C: quic::Connection<B>,
     B: Buf,
 {
-    /// Create a new HTTP/3 server connection with default settings
+    /// Create a new HTTP/3 server connection
     ///
-    /// Use a custom [`Builder`] with [`builder()`] to create a connection
-    /// with different settings.
-    /// Provide a Connection which implements [`quic::Connection`].
-    pub async fn new(conn: C) -> Result<Self, Error> {
-        builder().build(conn).await
+    /// Provide a connection endpoint which implements [`quic::Connection`] and
+    /// desired configuration for the server.
+    pub async fn new(conn: C, config: ServerConfig) -> Result<Self, Error> {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        Ok(Connection {
+            inner: ConnectionInner::new(
+                conn,
+                config.conn.max_field_section_size,
+                SharedStateRef::default(),
+                config.conn.enable_grease,
+            )
+            .await?,
+            max_field_section_size: config.conn.max_field_section_size,
+            request_end_send: sender,
+            request_end_recv: receiver,
+            ongoing_streams: HashSet::new(),
+        })
     }
 }
 
@@ -478,85 +510,6 @@ where
 //# So as to not unnecessarily limit
 //# parallelism, at least 100 request streams SHOULD be permitted at a
 //# time.
-
-/// Builder of HTTP/3 server connections.
-///
-/// Use this struct to create a new [`Connection`].
-/// Settings for the [`Connection`] can be provided here.
-///
-/// # Example
-///
-/// ```rust
-/// fn doc<C,B>(conn: C)
-/// where
-/// C: h3::quic::Connection<B>,
-/// B: bytes::Buf,
-/// {
-///     let mut server_builder = h3::server::builder();
-///     // Set the maximum header size
-///     server_builder.max_field_section_size(1000);
-///     // do not send grease types
-///     server_builder.send_grease(false);
-///     // Build the Connection
-///     let mut h3_conn = server_builder.build(conn);
-/// }
-/// ```
-pub struct Builder {
-    pub(super) max_field_section_size: u64,
-    pub(super) send_grease: bool,
-}
-
-impl Builder {
-    /// Creates a new [`Builder`] with default settings.
-    pub(super) fn new() -> Self {
-        Builder {
-            max_field_section_size: VarInt::MAX.0,
-            send_grease: true,
-        }
-    }
-    /// Set the maximum header size this client is willing to accept
-    ///
-    /// See [header size constraints] section of the specification for details.
-    ///
-    /// [header size constraints]: https://www.rfc-editor.org/rfc/rfc9114.html#name-header-size-constraints
-    pub fn max_field_section_size(&mut self, value: u64) -> &mut Self {
-        self.max_field_section_size = value;
-        self
-    }
-
-    /// Send grease values to the Client.
-    /// See [setting](https://www.rfc-editor.org/rfc/rfc9114.html#settings-parameters), [frame](https://www.rfc-editor.org/rfc/rfc9114.html#frame-reserved) and [stream](https://www.rfc-editor.org/rfc/rfc9114.html#stream-grease) for more information.
-    pub fn send_grease(&mut self, value: bool) -> &mut Self {
-        self.send_grease = value;
-        self
-    }
-}
-
-impl Builder {
-    /// Build an HTTP/3 connection from a QUIC connection
-    ///
-    /// This method creates a [`Connection`] instance with the settings in the [`Builder`].
-    pub async fn build<C, B>(&self, conn: C) -> Result<Connection<C, B>, Error>
-    where
-        C: quic::Connection<B>,
-        B: Buf,
-    {
-        let (sender, receiver) = mpsc::unbounded_channel();
-        Ok(Connection {
-            inner: ConnectionInner::new(
-                conn,
-                self.max_field_section_size,
-                SharedStateRef::default(),
-                self.send_grease,
-            )
-            .await?,
-            max_field_section_size: self.max_field_section_size,
-            request_end_send: sender,
-            request_end_recv: receiver,
-            ongoing_streams: HashSet::new(),
-        })
-    }
-}
 
 struct RequestEnd {
     request_end: mpsc::UnboundedSender<StreamId>,

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -138,11 +138,7 @@ where
     C: quic::Connection<B>,
     B: Buf,
 {
-    /// Create a new HTTP/3 server connection
-    ///
-    /// Provide a connection endpoint which implements [`quic::Connection`] and
-    /// desired configuration for the server.
-    pub async fn new(conn: C, config: ServerConfig) -> Result<Self, Error> {
+    async fn new(conn: C, config: ServerConfig) -> Result<Self, Error> {
         let (sender, receiver) = mpsc::unbounded_channel();
         Ok(Connection {
             inner: ConnectionInner::new(

--- a/h3/src/tests/connection.rs
+++ b/h3/src/tests/connection.rs
@@ -346,9 +346,7 @@ async fn control_close_send_error() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn, Default::default())
-            .await
-            .unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
         // Driver detects that the recieving side of the control stream has been closed
         assert_matches!(
             incoming.accept().await.map(|_| ()).unwrap_err().kind(),

--- a/h3/src/tests/connection.rs
+++ b/h3/src/tests/connection.rs
@@ -10,6 +10,7 @@ use http::{Request, Response, StatusCode};
 
 use crate::{
     client::{self, SendRequest},
+    config::{ClientConfig, ServerConfig},
     connection::ConnectionState,
     error::{Code, Error, Kind},
     proto::{
@@ -30,12 +31,14 @@ async fn connect() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let _ = client::new(pair.client().await).await.expect("client init");
+        let _ = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
     };
 
     let server_fut = async {
         let conn = server.next().await;
-        let _ = server::Connection::new(conn).await.unwrap();
+        let _ = server::new(conn, Default::default()).await.unwrap();
     };
 
     tokio::join!(server_fut, client_fut);
@@ -47,13 +50,15 @@ async fn accept_request_end_on_client_close() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let _ = client::new(pair.client().await).await.expect("client init");
+        let _ = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         // client is dropped, it will send H3_NO_ERROR
     };
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
         // Accept returns Ok(None)
         assert!(incoming.accept().await.unwrap().is_none());
     };
@@ -68,10 +73,12 @@ async fn server_drop_close() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let _ = server::Connection::new(conn).await.unwrap();
+        let _ = server::new(conn, Default::default()).await.unwrap();
     };
 
-    let (mut conn, mut send) = client::new(pair.client().await).await.expect("client init");
+    let (mut conn, mut send) = client::new(pair.client().await, Default::default())
+        .await
+        .expect("client init");
     let client_fut = async {
         let request_fut = async move {
             let mut request_stream = send
@@ -98,14 +105,16 @@ async fn client_close_only_on_last_sender_drop() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
         assert!(incoming.accept().await.unwrap().is_some());
         assert!(incoming.accept().await.unwrap().is_some());
         assert!(incoming.accept().await.unwrap().is_none());
     };
 
     let client_fut = async {
-        let (mut conn, mut send1) = client::new(pair.client().await).await.expect("client init");
+        let (mut conn, mut send1) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let mut send2 = send1.clone();
         let _ = send1
             .send_request(Request::get("http://no.way").body(()).unwrap())
@@ -136,7 +145,9 @@ async fn settings_exchange_client() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut conn, client) = client::new(pair.client().await).await.expect("client init");
+        let (mut conn, client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let settings_change = async {
             for _ in 0..10 {
                 if client
@@ -161,11 +172,8 @@ async fn settings_exchange_client() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::builder()
-            .max_field_section_size(12)
-            .build(conn)
-            .await
-            .unwrap();
+        let config = ServerConfig::new().max_field_section_size(12);
+        let mut incoming = server::new(conn, config).await.unwrap();
         incoming.accept().await.unwrap()
     };
 
@@ -179,9 +187,8 @@ async fn settings_exchange_server() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut conn, _client) = client::builder()
-            .max_field_section_size(12)
-            .build::<_, _, Bytes>(pair.client().await)
+        let config = ClientConfig::new().max_field_section_size(12);
+        let (mut conn, _client) = client::new(pair.client().await, config)
             .await
             .expect("client init");
         let drive = async move {
@@ -193,7 +200,7 @@ async fn settings_exchange_server() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
 
         let state = incoming.shared_state().clone();
         let accept = async { incoming.accept().await.unwrap() };
@@ -228,7 +235,9 @@ async fn client_error_on_bidi_recv() {
     }
 
     let client_fut = async {
-        let (mut conn, mut send) = client::new(pair.client().await).await.expect("client init");
+        let (mut conn, mut send) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-6.1
         //= type=test
@@ -291,7 +300,7 @@ async fn two_control_streams() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
         assert_matches!(
             incoming.accept().await.map(|_| ()).unwrap_err().kind(),
             Kind::Application {
@@ -325,16 +334,21 @@ async fn control_close_send_error() {
         //# error of type H3_CLOSED_CRITICAL_STREAM.
         control_stream.finish().await.unwrap(); // close the client control stream immediately
 
-        let (mut driver, _send) = client::new(h3_quinn::Connection::new(new_connection))
-            .await
-            .unwrap();
+        let (mut driver, _send) = client::new(
+            h3_quinn::Connection::new(new_connection),
+            Default::default(),
+        )
+        .await
+        .unwrap();
 
         future::poll_fn(|cx| driver.poll_close(cx)).await
     };
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::Connection::new(conn, Default::default())
+            .await
+            .unwrap();
         // Driver detects that the recieving side of the control stream has been closed
         assert_matches!(
             incoming.accept().await.map(|_| ()).unwrap_err().kind(),
@@ -376,7 +390,7 @@ async fn missing_settings() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
         assert_matches!(
             incoming.accept().await.map(|_| ()).unwrap_err().kind(),
             Kind::Application {
@@ -414,7 +428,7 @@ async fn control_stream_frame_unexpected() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
         assert_matches!(
             incoming.accept().await.map(|_| ()).unwrap_err().kind(),
             Kind::Application {
@@ -436,13 +450,15 @@ async fn timeout_on_control_frame_read() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut driver, _send_request) = client::new(pair.client().await).await.unwrap();
+        let (mut driver, _send_request) = client::new(pair.client().await, Default::default())
+            .await
+            .unwrap();
         let _ = future::poll_fn(|cx| driver.poll_close(cx)).await;
     };
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
         assert_matches!(
             incoming.accept().await.map(|_| ()).unwrap_err().kind(),
             Kind::Timeout
@@ -480,7 +496,7 @@ async fn goaway_from_client_not_push_id() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
         assert_matches!(
             incoming.accept().await.map(|_| ()).unwrap_err().kind(),
             Kind::Application {
@@ -509,9 +525,12 @@ async fn goaway_from_server_not_request_id() {
         control_stream.write_all(&buf[..]).await.unwrap();
         control_stream.finish().await.unwrap(); // close the client control stream immediately
 
-        let (mut driver, _send) = client::new(h3_quinn::Connection::new(new_connection))
-            .await
-            .unwrap();
+        let (mut driver, _send) = client::new(
+            h3_quinn::Connection::new(new_connection),
+            Default::default(),
+        )
+        .await
+        .unwrap();
 
         assert_matches!(
             future::poll_fn(|cx| driver.poll_close(cx))
@@ -556,7 +575,9 @@ async fn graceful_shutdown_server_rejects() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (_driver, mut send_request) = client::new(pair.client().await).await.unwrap();
+        let (_driver, mut send_request) = client::new(pair.client().await, Default::default())
+            .await
+            .unwrap();
 
         let mut first = send_request
             .send_request(Request::get("http://no.way").body(()).unwrap())
@@ -581,7 +602,7 @@ async fn graceful_shutdown_server_rejects() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
         let (_, stream) = incoming.accept().await.unwrap().unwrap();
         response(stream).await;
         incoming.shutdown(0).await.unwrap();
@@ -599,7 +620,9 @@ async fn graceful_shutdown_grace_interval() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut driver, mut send_request) = client::new(pair.client().await).await.unwrap();
+        let (mut driver, mut send_request) = client::new(pair.client().await, Default::default())
+            .await
+            .unwrap();
 
         // Sent as the connection is not shutting down
         let mut first = send_request
@@ -630,7 +653,7 @@ async fn graceful_shutdown_grace_interval() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
         let (_, first) = incoming.accept().await.unwrap().unwrap();
         incoming.shutdown(1).await.unwrap();
         let (_, in_flight) = incoming.accept().await.unwrap().unwrap();
@@ -655,7 +678,9 @@ async fn graceful_shutdown_closes_when_idle() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut driver, mut send_request) = client::new(pair.client().await).await.unwrap();
+        let (mut driver, mut send_request) = client::new(pair.client().await, Default::default())
+            .await
+            .unwrap();
 
         // Make continuous requests, ignoring GoAway because the connection is not driven
         while request(&mut send_request).await.is_ok() {
@@ -673,7 +698,7 @@ async fn graceful_shutdown_closes_when_idle() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
 
         let mut count = 0;
 

--- a/h3/src/tests/request.rs
+++ b/h3/src/tests/request.rs
@@ -7,6 +7,7 @@ use http::{request, HeaderMap, Request, Response, StatusCode};
 
 use crate::{
     client,
+    config::{ClientConfig, ServerConfig},
     connection::ConnectionState,
     error::{Code, Error, Kind},
     proto::{
@@ -29,7 +30,9 @@ async fn get() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut driver, mut client) = client::new(pair.client().await).await.expect("client init");
+        let (mut driver, mut client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let drive_fut = async { future::poll_fn(|cx| driver.poll_close(cx)).await };
         let req_fut = async {
             let mut request_stream = client
@@ -52,7 +55,7 @@ async fn get() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
         request_stream
@@ -81,7 +84,9 @@ async fn get_with_trailers_unknown_content_type() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut driver, mut client) = client::new(pair.client().await).await.expect("client init");
+        let (mut driver, mut client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let drive_fut = async { future::poll_fn(|cx| driver.poll_close(cx)).await };
         let req_fut = async {
             let mut request_stream = client
@@ -108,7 +113,7 @@ async fn get_with_trailers_unknown_content_type() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         let (_, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
         request_stream
@@ -143,7 +148,9 @@ async fn get_with_trailers_known_content_type() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut driver, mut client) = client::new(pair.client().await).await.expect("client init");
+        let (mut driver, mut client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let drive_fut = async { future::poll_fn(|cx| driver.poll_close(cx)).await };
         let req_fut = async {
             let mut request_stream = client
@@ -169,7 +176,7 @@ async fn get_with_trailers_known_content_type() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         let (_, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
         request_stream
@@ -205,7 +212,9 @@ async fn post() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut driver, mut client) = client::new(pair.client().await).await.expect("client init");
+        let (mut driver, mut client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let drive_fut = async { future::poll_fn(|cx| driver.poll_close(cx)).await };
         let req_fut = async {
             let mut request_stream = client
@@ -226,7 +235,7 @@ async fn post() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         let (_, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
         request_stream
@@ -259,7 +268,9 @@ async fn header_too_big_response_from_server() {
 
     let client_fut = async {
         // Do not poll driver so client doesn't know about server's max_field section size setting
-        let (mut driver, mut client) = client::new(pair.client().await).await.expect("client init");
+        let (mut driver, mut client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let drive_fut = async { future::poll_fn(|cx| driver.poll_close(cx)).await };
         let req_fut = async {
             let mut request_stream = client
@@ -282,11 +293,8 @@ async fn header_too_big_response_from_server() {
         //= type=test
         //# An HTTP/3 implementation MAY impose a limit on the maximum size of
         //# the message header it will accept on an individual HTTP message.
-        let mut incoming_req = server::builder()
-            .max_field_section_size(12)
-            .build(conn)
-            .await
-            .unwrap();
+        let config = ServerConfig::new().max_field_section_size(12);
+        let mut incoming_req = server::new(conn, config).await.unwrap();
 
         let err_kind = incoming_req.accept().await.map(|_| ()).unwrap_err().kind();
         assert_matches!(
@@ -311,7 +319,9 @@ async fn header_too_big_response_from_server_trailers() {
 
     let client_fut = async {
         // Do not poll driver so client doesn't know about server's max_field_section_size setting
-        let (mut driver, mut client) = client::new(pair.client().await).await.expect("client init");
+        let (mut driver, mut client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let drive_fut = async { future::poll_fn(|cx| driver.poll_close(cx)).await };
         let req_fut = async {
             let mut request_stream = client
@@ -340,11 +350,8 @@ async fn header_too_big_response_from_server_trailers() {
         //= type=test
         //# An HTTP/3 implementation MAY impose a limit on the maximum size of
         //# the message header it will accept on an individual HTTP message.
-        let mut incoming_req = server::builder()
-            .max_field_section_size(207)
-            .build(conn)
-            .await
-            .unwrap();
+        let config = ServerConfig::new().max_field_section_size(207);
+        let mut incoming_req = server::new(conn, config).await.unwrap();
 
         let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
         let _ = request_stream
@@ -374,7 +381,9 @@ async fn header_too_big_client_error() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut driver, mut client) = client::new(pair.client().await).await.expect("client init");
+        let (mut driver, mut client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let drive_fut = async { future::poll_fn(|cx| driver.poll_close(cx)).await };
         let req_fut = async {
             // pretend client already received server's settings
@@ -408,11 +417,8 @@ async fn header_too_big_client_error() {
         //= type=test
         //# An HTTP/3 implementation MAY impose a limit on the maximum size of
         //# the message header it will accept on an individual HTTP message.
-        server::builder()
-            .max_field_section_size(12)
-            .build(conn)
-            .await
-            .unwrap();
+        let config = ServerConfig::new().max_field_section_size(12);
+        server::new(conn, config).await.unwrap();
     };
 
     tokio::join!(server_fut, client_fut);
@@ -426,7 +432,9 @@ async fn header_too_big_client_error_trailer() {
 
     let client_fut = async {
         // Do not poll driver so client doesn't know about server's max_field_section_size setting
-        let (mut driver, mut client) = client::new(pair.client().await).await.expect("client init");
+        let (mut driver, mut client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let drive_fut = async { future::poll_fn(|cx| driver.poll_close(cx)).await };
         let req_fut = async {
             client
@@ -471,11 +479,8 @@ async fn header_too_big_client_error_trailer() {
         //= type=test
         //# An HTTP/3 implementation MAY impose a limit on the maximum size of
         //# the message header it will accept on an individual HTTP message.
-        let mut incoming_req = server::builder()
-            .max_field_section_size(207)
-            .build(conn)
-            .await
-            .unwrap();
+        let config = ServerConfig::new().max_field_section_size(207);
+        let mut incoming_req = server::new(conn, config).await.unwrap();
 
         let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
         let _ = request_stream
@@ -504,9 +509,8 @@ async fn header_too_big_discard_from_client() {
         //# process it.
 
         // Do not poll driver so client doesn't know about server's max_field section size setting
-        let (_conn, mut client) = client::builder()
-            .max_field_section_size(12)
-            .build::<_, _, Bytes>(pair.client().await)
+        let config = ClientConfig::new().max_field_section_size(12);
+        let (_conn, mut client) = client::new(pair.client().await, config)
             .await
             .expect("client init");
         let mut request_stream = client
@@ -534,7 +538,7 @@ async fn header_too_big_discard_from_client() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
         // pretend server didn't receive settings
@@ -589,9 +593,8 @@ async fn header_too_big_discard_from_client_trailers() {
         //# process it.
 
         // Do not poll driver so client doesn't know about server's max_field section size setting
-        let (mut driver, mut client) = client::builder()
-            .max_field_section_size(200)
-            .build::<_, _, Bytes>(pair.client().await)
+        let config = ClientConfig::new().max_field_section_size(200);
+        let (mut driver, mut client) = client::new(pair.client().await, config)
             .await
             .expect("client init");
         let drive_fut = async { future::poll_fn(|cx| driver.poll_close(cx)).await };
@@ -619,7 +622,7 @@ async fn header_too_big_discard_from_client_trailers() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
 
@@ -665,7 +668,7 @@ async fn header_too_big_server_error() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut driver, mut client) = client::new(pair.client().await) // header size limit faked for brevity
+        let (mut driver, mut client) = client::new(pair.client().await, Default::default()) // header size limit faked for brevity
             .await
             .expect("client init");
         let drive_fut = async { future::poll_fn(|cx| driver.poll_close(cx)).await };
@@ -683,7 +686,7 @@ async fn header_too_big_server_error() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
 
@@ -732,7 +735,7 @@ async fn header_too_big_server_error_trailers() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut driver, mut client) = client::new(pair.client().await) // header size limit faked for brevity
+        let (mut driver, mut client) = client::new(pair.client().await, Default::default()) // header size limit faked for brevity
             .await
             .expect("client init");
         let drive_fut = async { future::poll_fn(|cx| driver.poll_close(cx)).await };
@@ -750,7 +753,7 @@ async fn header_too_big_server_error_trailers() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
         request_stream
@@ -808,7 +811,9 @@ async fn get_timeout_client_recv_response() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut conn, mut client) = client::new(pair.client().await).await.expect("client init");
+        let (mut conn, mut client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let request_fut = async {
             let mut request_stream = client
                 .send_request(Request::get("http://localhost/salut").body(()).unwrap())
@@ -829,7 +834,7 @@ async fn get_timeout_client_recv_response() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         // _req must not be dropped, else the connection will be closed and the timeout
         // wont be triggered
@@ -848,7 +853,9 @@ async fn get_timeout_client_recv_data() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut conn, mut client) = client::new(pair.client().await).await.expect("client init");
+        let (mut conn, mut client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let request_fut = async {
             let mut request_stream = client
                 .send_request(Request::get("http://localhost/salut").body(()).unwrap())
@@ -870,7 +877,7 @@ async fn get_timeout_client_recv_data() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         let (_request, mut request_stream) = incoming_req.accept().await.expect("accept").unwrap();
         request_stream
@@ -896,7 +903,9 @@ async fn get_timeout_server_accept() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (mut conn, _client) = client::new(pair.client().await).await.expect("client init");
+        let (mut conn, _client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let request_fut = async {
             tokio::time::sleep(Duration::from_millis(500)).await;
         };
@@ -911,7 +920,7 @@ async fn get_timeout_server_accept() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         assert_matches!(
             incoming_req.accept().await.map(|_| ()).unwrap_err().kind(),
@@ -930,7 +939,9 @@ async fn post_timeout_server_recv_data() {
     let mut server = pair.server();
 
     let client_fut = async {
-        let (_conn, mut client) = client::new(pair.client().await).await.expect("client init");
+        let (_conn, mut client) = client::new(pair.client().await, Default::default())
+            .await
+            .expect("client init");
         let _request_stream = client
             .send_request(Request::post("http://localhost/salut").body(()).unwrap())
             .await
@@ -940,7 +951,7 @@ async fn post_timeout_server_recv_data() {
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming_req = server::Connection::new(conn).await.unwrap();
+        let mut incoming_req = server::new(conn, Default::default()).await.unwrap();
 
         let (_, mut req_stream) = incoming_req.accept().await.expect("accept").unwrap();
         assert_matches!(
@@ -1418,9 +1429,12 @@ where
             .map(|_| ());
         check(res);
 
-        let (mut driver, _send) = client::new(h3_quinn::Connection::new(new_connection))
-            .await
-            .unwrap();
+        let (mut driver, _send) = client::new(
+            h3_quinn::Connection::new(new_connection),
+            Default::default(),
+        )
+        .await
+        .unwrap();
 
         let res = future::poll_fn(|cx| driver.poll_close(cx))
             .await
@@ -1431,7 +1445,7 @@ where
 
     let server_fut = async {
         let conn = server.next().await;
-        let mut incoming = server::Connection::new(conn).await.unwrap();
+        let mut incoming = server::new(conn, Default::default()).await.unwrap();
         let (_, mut stream) = incoming
             .accept()
             .await?


### PR DESCRIPTION
Introducing some config builders to replace current endpoint builders.

```rs
// should be passed to ConnectionInner
ConnectionConfig {
    // configs for the shared connection implementation
}

ClientConfig {
    conn: ConnectionConfig,
    // client-specific configs...
}

ServerConfig {
    conn: ConnectionConfig,
    // server-specific configs...
}
```

Potential benefits:
* config structs feel more self-contained and natural to pass around
* opens up opportunities to do conversions like `impl From<ConnectionConfig> for Settings`
* dedup current builder code

TODO
* Typing of `client::new()` and `server::new()` should be more generic, with `Buf` instead of `Bytes`. But there seems to some usability issue with `Buf`: the typing can't be inferred, have to use explicit typing on `new()`. It feels like the issues comes from h3-quinn. I'm not sure.
* A handy API for using default config, like `client::new_default(conn)` (probably not..).