### PR TITLE
Enable extension negotiation

### DIFF
--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -156,9 +156,10 @@ where
             method,
             uri,
             headers,
+            extensions,
             ..
         } = parts;
-        let headers = Header::request(method, uri, headers)?;
+        let headers = Header::request(method, uri, headers, extensions)?;
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-4.1
         //= type=implication

--- a/h3/src/tests/request.rs
+++ b/h3/src/tests/request.rs
@@ -1330,9 +1330,10 @@ fn request_encode<B: BufMut>(buf: &mut B, req: http::Request<()>) {
         method,
         uri,
         headers,
+        extensions,
         ..
     } = parts;
-    let headers = Header::request(method, uri, headers).unwrap();
+    let headers = Header::request(method, uri, headers, extensions).unwrap();
     let mut block = BytesMut::new();
     qpack::encode_stateless(&mut block, headers).unwrap();
     Frame::headers(block).encode_with_payload(buf);


### PR DESCRIPTION
This is an attempt to remove some roadblock to future extension support.

Both WebSocket/WebTransport over HTTP/3 rely on CONNECT requests bearing a `:protocol` pseudo-header to create new sessions. However, `:protocol` is deemed invalid in h3.

I'm assuming people would use `http::Extensions` to hold the value of the `:protocol` header. Is there a better option in `http` for this?