### PR TITLE
Fix wrong link for PROPOSAL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An async HTTP/3 implementation.
 This crate provides an [HTTP/3][spec] implementation that is generic over a provided QUIC transport. This allows the project to focus on just HTTP/3, while letting users pick their QUIC implementation based on their specific needs. It includes client and server APIs. Check the original [design][] for more details.
 
 [spec]: https://www.rfc-editor.org/rfc/rfc9114
-[design]: design/PROPOSAL.md
+[design]: docs/PROPOSAL.md
 
 ## Status
 


### PR DESCRIPTION
Fix wrong link for PROPOSAL.md after the file was moved to a different location.