### PR TITLE
fix client shutdown and push id / stream id confusion

### DIFF
--- a/h3/src/error.rs
+++ b/h3/src/error.rs
@@ -411,7 +411,8 @@ impl From<frame::FrameStreamError> for Error {
                 .with_reason("received incomplete frame", ErrorLevel::ConnectionError),
 
             frame::FrameStreamError::Proto(e) => match e {
-                proto::frame::FrameError::InvalidStreamId(_) => Code::H3_ID_ERROR,
+                proto::frame::FrameError::InvalidStreamId(_)
+                | proto::frame::FrameError::InvalidPushId(_) => Code::H3_ID_ERROR,
                 proto::frame::FrameError::Settings(_) => Code::H3_SETTINGS_ERROR,
                 proto::frame::FrameError::UnsupportedFrame(_)
                 | proto::frame::FrameError::UnknownFrame(_) => Code::H3_FRAME_UNEXPECTED,

--- a/h3/src/proto/mod.rs
+++ b/h3/src/proto/mod.rs
@@ -3,5 +3,6 @@ pub mod coding;
 pub mod frame;
 #[allow(dead_code)]
 pub mod headers;
+pub mod push;
 pub mod stream;
 pub mod varint;

--- a/h3/src/proto/push.rs
+++ b/h3/src/proto/push.rs
@@ -1,0 +1,44 @@
+use std::convert::TryFrom;
+use std::fmt::{self, Display};
+
+use super::varint::VarInt;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct PushId(pub(crate) u64);
+
+#[derive(Debug, PartialEq)]
+pub struct InvalidPushId(u64);
+
+impl TryFrom<u64> for PushId {
+    type Error = InvalidPushId;
+    fn try_from(v: u64) -> Result<Self, Self::Error> {
+        match VarInt::try_from(v) {
+            Ok(id) => Ok(id.into()),
+            Err(_) => Err(InvalidPushId(v)),
+        }
+    }
+}
+
+impl Display for InvalidPushId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid push id: {:x}", self.0)
+    }
+}
+
+impl From<VarInt> for PushId {
+    fn from(v: VarInt) -> Self {
+        Self(v.0)
+    }
+}
+
+impl From<PushId> for VarInt {
+    fn from(v: PushId) -> Self {
+        Self(v.0)
+    }
+}
+
+impl fmt::Display for PushId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "push {}", self.0)
+    }
+}

--- a/h3/src/proto/stream.rs
+++ b/h3/src/proto/stream.rs
@@ -89,9 +89,7 @@ impl fmt::Display for StreamId {
 }
 
 impl StreamId {
-    pub(crate) fn first_request() -> Self {
-        Self::new(0, Dir::Bi, Side::Client)
-    }
+    pub(crate) const FIRST_REQUEST: Self = Self::new(0, Dir::Bi, Side::Client);
 
     /// Is this a client-initiated request?
     pub fn is_request(&self) -> bool {
@@ -113,7 +111,7 @@ impl StreamId {
     }
 
     /// Create a new StreamId
-    fn new(index: u64, dir: Dir, initiator: Side) -> Self {
+    const fn new(index: u64, dir: Dir, initiator: Side) -> Self {
         StreamId((index as u64) << 2 | (dir as u64) << 1 | initiator as u64)
     }
 
@@ -139,6 +137,18 @@ impl TryFrom<u64> for StreamId {
             return Err(InvalidStreamId(v));
         }
         Ok(Self(v))
+    }
+}
+
+impl From<VarInt> for StreamId {
+    fn from(v: VarInt) -> Self {
+        Self(v.0)
+    }
+}
+
+impl From<StreamId> for VarInt {
+    fn from(v: StreamId) -> Self {
+        Self(v.0)
     }
 }
 

--- a/h3/src/proto/varint.rs
+++ b/h3/src/proto/varint.rs
@@ -28,7 +28,7 @@ impl VarInt {
         if x < 2u64.pow(62) {
             Ok(VarInt(x))
         } else {
-            Err(VarIntBoundsExceeded)
+            Err(VarIntBoundsExceeded(x))
         }
     }
 
@@ -192,4 +192,4 @@ impl<T: BufMut> BufMutExt for T {
 }
 /// Error returned when constructing a `VarInt` from a value >= 2^62
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct VarIntBoundsExceeded;
+pub struct VarIntBoundsExceeded(pub(crate) u64);

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -287,7 +287,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::stream::StreamId;
 
     #[test]
     fn write_buf_encode_streamtype() {
@@ -299,7 +298,7 @@ mod tests {
 
     #[test]
     fn write_buf_encode_frame() {
-        let wbuf = WriteBuf::<Bytes>::from(Frame::Goaway(StreamId(2)));
+        let wbuf = WriteBuf::<Bytes>::from(Frame::Goaway(VarInt(2)));
 
         assert_eq!(wbuf.chunk(), b"\x07\x01\x02");
         assert_eq!(wbuf.len, 3);
@@ -307,7 +306,7 @@ mod tests {
 
     #[test]
     fn write_buf_encode_streamtype_then_frame() {
-        let wbuf = WriteBuf::<Bytes>::from((StreamType::ENCODER, Frame::Goaway(StreamId(2))));
+        let wbuf = WriteBuf::<Bytes>::from((StreamType::ENCODER, Frame::Goaway(VarInt(2))));
 
         assert_eq!(wbuf.chunk(), b"\x02\x07\x01\x02");
     }

--- a/h3/src/tests/request.rs
+++ b/h3/src/tests/request.rs
@@ -13,7 +13,7 @@ use crate::{
         coding::Encode,
         frame::{self, Frame, FrameType},
         headers::Header,
-        stream::StreamId,
+        push::PushId,
         varint::VarInt,
     },
     qpack, server,
@@ -1135,10 +1135,10 @@ async fn request_valid_unkown_frame_after_trailers() {
 //# connection error of type H3_FRAME_UNEXPECTED.
 fn invalid_request_frames() -> Vec<Frame<Bytes>> {
     vec![
-        Frame::CancelPush(StreamId(0)),
+        Frame::CancelPush(PushId(0)),
         Frame::Settings(frame::Settings::default()),
-        Frame::Goaway(StreamId(1)),
-        Frame::MaxPushId(StreamId(1)),
+        Frame::Goaway(VarInt(1)),
+        Frame::MaxPushId(PushId(1)),
     ]
 }
 


### PR DESCRIPTION
Fixes #174 and #175

Note: On top of this change ids could use a bit of a clean-up. They aren't used consistently and differ in how well initialization and conversion are protected from creating invalid values etc. But that is beyond the scope of this PR, I would like to address that in a follow-up.