### PR TITLE
deps: update Rustls to 0.21.0, Quinn to 0.10.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ env:
   RUST_BACKTRACE: 1
   toolchain_style: stable
   toolchain_msrv: 1.57
-  toolchain_h3_quinn_msrv: 1.59
+  toolchain_h3_quinn_msrv: 1.63
   toolchain_doc: nightly-2023-03-22
   toolchain_lint: stable
   toolchain_fuzz: nightly-2023-03-22

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,9 +12,9 @@ futures = "0.3"
 h3 = { path = "../h3" }
 h3-quinn = { path = "../h3-quinn" }
 http = "0.2"
-quinn = { version = "0.9", default-features = false, features = ["runtime-tokio", "tls-rustls", "ring"] }
+quinn = { version = "0.10", default-features = false, features = ["runtime-tokio", "tls-rustls", "ring"] }
 rcgen = { version = "0.10" }
-rustls = { version = "0.20", features = ["dangerous_configuration"] }
+rustls = { version = "0.21", features = ["dangerous_configuration"] }
 rustls-native-certs = "0.6"
 structopt = "0.3"
 tokio = { version = "1.27", features = ["full"] }

--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "h3-quinn"
 version = "0.0.2"
-rust-version = "1.59"
+rust-version = "1.63"
 authors = ["Jean-Christophe BEGUE <jc.begue@pm.me>"]
 edition = "2018"
 documentation = "https://docs.rs/h3-quinn"
@@ -15,7 +15,7 @@ license = "MIT"
 [dependencies]
 h3 = { version = "0.0.2", path = "../h3" }
 bytes = "1"
-quinn = { version = "0.9.3", default-features = false }
-quinn-proto = { version = "0.9.2", default-features = false }
+quinn = { version = "0.10", default-features = false }
+quinn-proto = { version = "0.10", default-features = false }
 tokio-util = { version = "0.7.7" }
 futures = { version = "0.3.27" }

--- a/h3/Cargo.toml
+++ b/h3/Cargo.toml
@@ -31,14 +31,14 @@ fastrand = "1.9.0"
 assert_matches = "1.5.0"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 proptest = "1"
-quinn = { version = "0.9.3", default-features = false, features = [
+quinn = { version = "0.10", default-features = false, features = [
     "runtime-tokio",
     "tls-rustls",
     "ring",
 ] }
-quinn-proto = { version = "0.9.2", default-features = false }
+quinn-proto = { version = "0.10", default-features = false }
 rcgen = "0.10"
-rustls = "0.20"
+rustls = "0.21"
 tokio = { version = "1", features = ["rt", "macros", "io-util", "io-std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
     "fmt",


### PR DESCRIPTION
This commit bumps the Rustls dependency from 0.20 to 0.21. Similarly it bumps the Quinn dependency from 0.9 to 0.10 to include that crate's transitive update to Rustls 0.21.

To support Quinn 0.10's transitive dependency on socket2 v0.5.2 we must also increase the h3-quinn MSRV from 1.59.0 to 1.63.0.

This will help unblock the same dependency bumps in the downstream Reqwest crate: https://github.com/seanmonstar/reqwest/pull/1791