### PR TITLE
Initial support for RFC 9298 "Proxying UDP in HTTP"

### DIFF
--- a/h3/src/ext.rs
+++ b/h3/src/ext.rs
@@ -22,6 +22,15 @@ impl Protocol {
     pub const WEB_TRANSPORT: Protocol = Protocol(ProtocolInner::WebTransport);
     /// RFC 9298 protocol
     pub const CONNECT_UDP: Protocol = Protocol(ProtocolInner::ConnectUdp);
+
+    /// Return a &str representation of the `:protocol` pseudo-header value
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        match self.0 {
+            ProtocolInner::WebTransport => "webtransport",
+            ProtocolInner::ConnectUdp => "connect-udp",
+        }
+    }
 }
 
 #[derive(Copy, PartialEq, Debug, Clone)]

--- a/h3/src/ext.rs
+++ b/h3/src/ext.rs
@@ -20,11 +20,14 @@ pub struct Protocol(ProtocolInner);
 impl Protocol {
     /// WebTransport protocol
     pub const WEB_TRANSPORT: Protocol = Protocol(ProtocolInner::WebTransport);
+    /// RFC 9298 protocol
+    pub const CONNECT_UDP: Protocol = Protocol(ProtocolInner::ConnectUdp);
 }
 
 #[derive(Copy, PartialEq, Debug, Clone)]
 enum ProtocolInner {
     WebTransport,
+    ConnectUdp,
 }
 
 /// Error when parsing the protocol
@@ -36,6 +39,7 @@ impl FromStr for Protocol {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "webtransport" => Ok(Self(ProtocolInner::WebTransport)),
+            "connect-udp" => Ok(Self(ProtocolInner::ConnectUdp)),
             _ => Err(InvalidProtocol),
         }
     }

--- a/h3/src/proto/headers.rs
+++ b/h3/src/proto/headers.rs
@@ -181,6 +181,10 @@ impl Iterator for HeaderIter {
             if let Some(status) = pseudo.status.take() {
                 return Some((":status", status.as_str()).into());
             }
+
+            if let Some(protocol) = pseudo.protocol.take() {
+                return Some((":protocol", protocol.as_str().as_bytes()).into());
+            }
         }
 
         self.pseudo = None;


### PR DESCRIPTION
1.  Add support for RFC 9298 in `:protocol` extension
2. bugfix: Properly encode `:protocol` header
    ```
    Previously, the `:protocol` header wouldn't be set when the `Protocol`
    extension was active for a `Request`.
    
    This was most likely because the Webtransport PR (the PR that introduced
    the `Protocol` extension) did not include a client implementation and
    thus did not test this.
    ```