### PR TITLE
bugfix: Actually encode extensions in header

### DIFF
--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -159,9 +159,10 @@ where
             method,
             uri,
             headers,
+            extensions,
             ..
         } = parts;
-        let headers = Header::request(method, uri, headers, Default::default())?;
+        let headers = Header::request(method, uri, headers, extensions)?;
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-4.1
         //= type=implication

--- a/h3/src/tests/request.rs
+++ b/h3/src/tests/request.rs
@@ -1337,9 +1337,10 @@ fn request_encode<B: BufMut>(buf: &mut B, req: http::Request<()>) {
         method,
         uri,
         headers,
+        extensions,
         ..
     } = parts;
-    let headers = Header::request(method, uri, headers, Default::default()).unwrap();
+    let headers = Header::request(method, uri, headers, extensions).unwrap();
     let mut block = BytesMut::new();
     qpack::encode_stateless(&mut block, headers).unwrap();
     Frame::headers(block).encode_with_payload(buf);


### PR DESCRIPTION
This was previously attemped in 0dffc9008f65dc0aea272623a5f17c38df37f737, but I didn't expect that all of the request's extensions have been ignored when passed to `Header::request`, this fixed it.

A previous attempt (not mine) is found here: #159