### PR TITLE
Expose setting to disable grease

### DIFF
--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -504,6 +504,15 @@ impl Builder {
         self
     }
 
+    /// Just like in HTTP/2, HTTP/3 also uses the concept of "grease"
+    /// to prevent potential interoperability issues in the future.
+    /// In HTTP/3, the concept of grease is used to ensure that the protocol can evolve
+    /// and accommodate future changes without breaking existing implementations.
+    pub fn send_grease(&mut self, enabled: bool) -> &mut Self {
+        self.config.send_grease = enabled;
+        self
+    }
+
     /// Create a new HTTP/3 client from a `quic` connection
     pub async fn build<C, O, B>(
         &mut self,


### PR DESCRIPTION
This exposes a method on `h3::client::Builder` to disable grease.

I copied the documentation from [`Config::send_grease`](https://github.com/daxpedda/h3/blob/a38b194a2f00dc0b2b60564c299093204d349d7e/h3/src/config.rs#L7-L11). Let me know if you want me to add anything else to it.