### PR TITLE
Split out a `Settings` struct from `Config`

### DIFF
--- a/h3-webtransport/src/server.rs
+++ b/h3-webtransport/src/server.rs
@@ -84,15 +84,15 @@ where
         //
         // However, it is still advantageous to show a log on the server as (attempting) to
         // establish a WebTransportSession without the proper h3 config is usually a mistake.
-        if !conn.inner.config.enable_webtransport() {
+        if !conn.inner.config.settings.enable_webtransport() {
             tracing::warn!("Server does not support webtransport");
         }
 
-        if !conn.inner.config.enable_datagram() {
+        if !conn.inner.config.settings.enable_datagram() {
             tracing::warn!("Server does not support datagrams");
         }
 
-        if !conn.inner.config.enable_extended_connect() {
+        if !conn.inner.config.settings.enable_extended_connect() {
             tracing::warn!("Server does not support CONNECT");
         }
 

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -506,7 +506,7 @@ impl Builder {
     ///
     /// [header size constraints]: https://www.rfc-editor.org/rfc/rfc9114.html#name-header-size-constraints
     pub fn max_field_section_size(&mut self, value: u64) -> &mut Self {
-        self.config.max_field_section_size = value;
+        self.config.settings.max_field_section_size = value;
         self
     }
 
@@ -544,7 +544,7 @@ impl Builder {
                 open,
                 conn_state,
                 conn_waker,
-                max_field_section_size: self.config.max_field_section_size,
+                max_field_section_size: self.config.settings.max_field_section_size,
                 sender_count: Arc::new(AtomicUsize::new(1)),
                 send_grease_frame: self.config.send_grease,
                 _buf: PhantomData,

--- a/h3/src/config.rs
+++ b/h3/src/config.rs
@@ -1,4 +1,9 @@
-use crate::proto::varint::VarInt;
+use std::{
+    convert::TryFrom,
+    ops::{Deref, DerefMut},
+};
+
+use crate::proto::{frame, varint::VarInt};
 
 /// Configures the HTTP/3 connection
 #[derive(Debug, Clone, Copy)]
@@ -13,6 +18,13 @@ pub struct Config {
     #[cfg(test)]
     pub(crate) send_settings: bool,
 
+    /// HTTP/3 Settings
+    pub(crate) settings: Settings,
+}
+
+/// HTTP/3 Settings
+#[derive(Debug, Clone, Copy)]
+pub struct Settings {
     /// The MAX_FIELD_SECTION_SIZE in HTTP/3 refers to the maximum size of the dynamic table used in HPACK compression.
     /// HPACK is the compression algorithm used in HTTP/3 to reduce the size of the header fields in HTTP requests and responses.
 
@@ -34,7 +46,107 @@ pub struct Config {
     pub(crate) max_webtransport_sessions: u64,
 }
 
-impl Config {
+impl From<&frame::Settings> for Settings {
+    fn from(settings: &frame::Settings) -> Self {
+        let defaults: Self = Default::default();
+        Self {
+            max_field_section_size: settings
+                .get(frame::SettingId::MAX_HEADER_LIST_SIZE)
+                .unwrap_or(defaults.max_field_section_size),
+            enable_webtransport: settings
+                .get(frame::SettingId::ENABLE_WEBTRANSPORT)
+                .map(|value| value != 0)
+                .unwrap_or(defaults.enable_webtransport),
+            max_webtransport_sessions: settings
+                .get(frame::SettingId::WEBTRANSPORT_MAX_SESSIONS)
+                .unwrap_or(defaults.max_webtransport_sessions),
+            enable_datagram: settings
+                .get(frame::SettingId::H3_DATAGRAM)
+                .map(|value| value != 0)
+                .unwrap_or(defaults.enable_datagram),
+            enable_extended_connect: settings
+                .get(frame::SettingId::ENABLE_CONNECT_PROTOCOL)
+                .map(|value| value != 0)
+                .unwrap_or(defaults.enable_extended_connect),
+        }
+    }
+}
+
+impl TryFrom<Config> for frame::Settings {
+    type Error = frame::SettingsError;
+    fn try_from(value: Config) -> Result<Self, Self::Error> {
+        let mut settings = frame::Settings::default();
+
+        let Config {
+            send_grease,
+            #[cfg(test)]
+                send_settings: _,
+            settings:
+                Settings {
+                    max_field_section_size,
+                    enable_webtransport,
+                    enable_extended_connect,
+                    enable_datagram,
+                    max_webtransport_sessions,
+                },
+        } = value;
+
+        if send_grease {
+            //  Grease Settings (https://www.rfc-editor.org/rfc/rfc9114.html#name-defined-settings-parameters)
+            //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.4.1
+            //# Setting identifiers of the format 0x1f * N + 0x21 for non-negative
+            //# integer values of N are reserved to exercise the requirement that
+            //# unknown identifiers be ignored.  Such settings have no defined
+            //# meaning.  Endpoints SHOULD include at least one such setting in their
+            //# SETTINGS frame.
+
+            //= https://www.rfc-editor.org/rfc/rfc9114#section-7.2.4.1
+            //# Setting identifiers that were defined in [HTTP/2] where there is no
+            //# corresponding HTTP/3 setting have also been reserved
+            //# (Section 11.2.2).  These reserved settings MUST NOT be sent, and
+            //# their receipt MUST be treated as a connection error of type
+            //# H3_SETTINGS_ERROR.
+            match settings.insert(frame::SettingId::grease(), 0) {
+                Ok(_) => (),
+                Err(err) => tracing::warn!("Error when adding the grease Setting. Reason {}", err),
+            }
+        }
+
+        settings.insert(
+            frame::SettingId::MAX_HEADER_LIST_SIZE,
+            max_field_section_size,
+        )?;
+        settings.insert(
+            frame::SettingId::ENABLE_CONNECT_PROTOCOL,
+            enable_extended_connect as u64,
+        )?;
+        settings.insert(
+            frame::SettingId::ENABLE_WEBTRANSPORT,
+            enable_webtransport as u64,
+        )?;
+        settings.insert(frame::SettingId::H3_DATAGRAM, enable_datagram as u64)?;
+        settings.insert(
+            frame::SettingId::WEBTRANSPORT_MAX_SESSIONS,
+            max_webtransport_sessions,
+        )?;
+
+        Ok(settings)
+    }
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            max_field_section_size: VarInt::MAX.0,
+            enable_webtransport: false,
+            enable_extended_connect: false,
+            enable_datagram: false,
+            max_webtransport_sessions: 0,
+        }
+    }
+}
+
+impl Settings {
     /// https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.1
     /// Sets `SETTINGS_ENABLE_WEBTRANSPORT` if enabled
     pub fn enable_webtransport(&self) -> bool {
@@ -58,14 +170,25 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            max_field_section_size: VarInt::MAX.0,
             send_grease: true,
             #[cfg(test)]
             send_settings: true,
-            enable_webtransport: false,
-            enable_extended_connect: false,
-            enable_datagram: false,
-            max_webtransport_sessions: 0,
+            settings: Default::default(),
         }
+    }
+}
+
+impl Deref for Config {
+    type Target = Settings;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.settings
+    }
+}
+
+impl DerefMut for Config {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.settings
     }
 }

--- a/h3/src/config.rs
+++ b/h3/src/config.rs
@@ -1,7 +1,4 @@
-use std::{
-    convert::TryFrom,
-    ops::{Deref, DerefMut},
-};
+use std::convert::TryFrom;
 
 use crate::proto::{frame, varint::VarInt};
 
@@ -19,7 +16,7 @@ pub struct Config {
     pub(crate) send_settings: bool,
 
     /// HTTP/3 Settings
-    pub(crate) settings: Settings,
+    pub settings: Settings,
 }
 
 /// HTTP/3 Settings
@@ -175,20 +172,5 @@ impl Default for Config {
             send_settings: true,
             settings: Default::default(),
         }
-    }
-}
-
-impl Deref for Config {
-    type Target = Settings;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.settings
-    }
-}
-
-impl DerefMut for Config {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.settings
     }
 }

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -352,7 +352,9 @@ where
                         );
                     }
                 }
-                AcceptedRecvStream::WebTransportUni(id, s) if self.config.enable_webtransport => {
+                AcceptedRecvStream::WebTransportUni(id, s)
+                    if self.config.settings.enable_webtransport =>
+                {
                     // Store until someone else picks it up, like a webtransport session which is
                     // not yet established.
                     self.accepted_streams.wt_uni_streams.push((id, s))

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -568,7 +568,7 @@ impl Builder {
     ///
     /// [header size constraints]: https://www.rfc-editor.org/rfc/rfc9114.html#name-header-size-constraints
     pub fn max_field_section_size(&mut self, value: u64) -> &mut Self {
-        self.config.max_field_section_size = value;
+        self.config.settings.max_field_section_size = value;
         self
     }
 
@@ -590,19 +590,19 @@ impl Builder {
     /// and `max_webtransport_sessions`.
     #[inline]
     pub fn enable_webtransport(&mut self, value: bool) -> &mut Self {
-        self.config.enable_webtransport = value;
+        self.config.settings.enable_webtransport = value;
         self
     }
 
     /// Enables the CONNECT protocol
     pub fn enable_connect(&mut self, value: bool) -> &mut Self {
-        self.config.enable_extended_connect = value;
+        self.config.settings.enable_extended_connect = value;
         self
     }
 
     /// Limits the maximum number of WebTransport sessions
     pub fn max_webtransport_sessions(&mut self, value: u64) -> &mut Self {
-        self.config.max_webtransport_sessions = value;
+        self.config.settings.max_webtransport_sessions = value;
         self
     }
 
@@ -610,7 +610,7 @@ impl Builder {
     ///
     /// See: <https://www.rfc-editor.org/rfc/rfc9297#section-2.1.1>
     pub fn enable_datagram(&mut self, value: bool) -> &mut Self {
-        self.config.enable_datagram = value;
+        self.config.settings.enable_datagram = value;
         self
     }
 }
@@ -627,7 +627,7 @@ impl Builder {
         let (sender, receiver) = mpsc::unbounded_channel();
         Ok(Connection {
             inner: ConnectionInner::new(conn, SharedStateRef::default(), self.config).await?,
-            max_field_section_size: self.config.max_field_section_size,
+            max_field_section_size: self.config.settings.max_field_section_size,
             request_end_send: sender,
             request_end_recv: receiver,
             ongoing_streams: HashSet::new(),


### PR DESCRIPTION
The `Settings` struct is an abstract representation of `frame::Settings`.

Basically:

- When talking about our own connection, we should use `Config`.
  - e.g. in `ConnectionInner`'s `config` field

- When talking about a peer's settings, we should use `Settings.
  - e.g. in `SharedState`'s `peer_config` field

This separation allows us to define some conversions:

- `Config` -> `frame::Settings`
  - used in `ConnectionInner::new`

- `&frame::Settings` -> `Settings`
  - used in `ConnectionInner::poll_control`