### PR TITLE
h3 v0.0.3

### DIFF
--- a/changelog-h3.md
+++ b/changelog-h3.md
@@ -1,3 +1,15 @@
+### v0.0.3 (2023-10-23)
+
+* Split out a `Settings` struct from `Config` ([a57ed22](https://github.com/hyperium/h3/commit/a57ed224ac5d17a635eb71eb6f83c1196f581a51))
+* Add a test-only send_settings config option ([3991dca](https://github.com/hyperium/h3/commit/3991dcaf3801595e49d0bb7fb1649b4cf50292b7))
+* Expose setting to disable grease ([dccb3cd](https://github.com/hyperium/h3/commit/dccb3cdae9d5a9d720fae5f774b53f0bd8a16019))
+* bugfix: Actually encode extensions in header ([a38b194](https://github.com/hyperium/h3/commit/a38b194a2f00dc0b2b60564c299093204d349d7e))
+* Initial support for RFC 9298 "Proxying UDP in HTTP" ([5a87580](https://github.com/hyperium/h3/commit/5a87580bd060b6a7d4dc625e990526d6998fda5c))
+* Bump H3_DATAGRAM setting ID according to RFC9297 ([58c8e5c](https://github.com/hyperium/h3/commit/58c8e5cecb2b0c367d738989fe9c505936bc5ff3))
+* Fix `cargo doc` warning ([3ef7c1a](https://github.com/hyperium/h3/commit/3ef7c1a37b635e8446322d8f8d3a68580a208ad8))
+* Initial WebTransport support (in h3 is just some necessary code to support a WebTransport crate which contains most of the WebTransport implementation) ([22da938](https://github.com/hyperium/h3/commit/22da9387f19d724852b3bf1dfd7e66f0fd45cb81))
+
+
 ### v0.0.2 (2023-04-11)
 
 #### Bug Fixes

--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "web-programming"]
 license = "MIT"
 
 [dependencies]
-h3 = { version = "0.0.2", path = "../h3" }
+h3 = { version = "0.0.3", path = "../h3" }
 bytes = "1"
 quinn = { version = "0.10", default-features = false, features = [
     "futures-io",

--- a/h3-webtransport/Cargo.toml
+++ b/h3-webtransport/Cargo.toml
@@ -14,6 +14,6 @@ tracing = "0.1.37"
 tokio = { version = "1.28", default_features = false }
 
 [dependencies.h3]
-version = "0.0.2"
+version = "0.0.3"
 path = "../h3"
 features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes"]

--- a/h3/Cargo.toml
+++ b/h3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "h3"
-version = "0.0.2"
+version = "0.0.3"
 rust-version = "1.63"
 authors = [
     "Sean McArthur <sean@seanmonstar.com>",


### PR DESCRIPTION
The current version of h3-quinn (v0.0.3) probably wont work with this. So i will create a release for h3-quinn v0.0.4 right after i published this one. 