### PR TITLE
expose poller varieties of recv_data and send_data

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -48,5 +48,13 @@ name = "server"
 path = "server.rs"
 
 [[example]]
+name = "client_streaming"
+path = "client_streaming.rs"
+
+[[example]]
+name = "server_streaming"
+path = "server_streaming.rs"
+
+[[example]]
 name = "webtransport_server"
 path = "webtransport_server.rs"

--- a/examples/client_streaming.rs
+++ b/examples/client_streaming.rs
@@ -1,0 +1,283 @@
+use std::{path::PathBuf, sync::Arc, time::Duration};
+
+use bytes::Bytes;
+use bytes::{Buf, BytesMut};
+use futures::future;
+use h3::client::RequestStream;
+use std::io::ErrorKind;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use structopt::StructOpt;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+use tokio::io::ReadBuf;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tracing::{error, info};
+
+use h3_quinn::quinn;
+
+static ALPN: &[u8] = b"h3";
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "server")]
+struct Opt {
+    #[structopt(
+        long,
+        short,
+        default_value = "examples/ca.cert",
+        help = "Certificate of CA who issues the server certificate"
+    )]
+    pub ca: PathBuf,
+
+    #[structopt(name = "keylogfile", long)]
+    pub key_log_file: bool,
+
+    #[structopt()]
+    pub uri: String,
+}
+
+pub struct Streaming {
+    stream: RequestStream<h3_quinn::BidiStream<Bytes>, Bytes>,
+    pending_read: Bytes,
+    pending_write: bool,
+}
+
+impl Streaming {
+    pub(crate) fn new(stream: RequestStream<h3_quinn::BidiStream<Bytes>, Bytes>) -> Self {
+        Self {
+            stream,
+            pending_read: Bytes::new(),
+            pending_write: false,
+        }
+    }
+
+    fn copy_from_pending(&mut self, copy_to: &mut ReadBuf<'_>) {
+        let copy = std::cmp::min(copy_to.remaining(), self.pending_read.len());
+        copy_to.put_slice(&self.pending_read[0..copy]);
+        self.pending_read.advance(copy);
+    }
+}
+
+fn to_std_err(e: h3::error::Error) -> std::io::Error {
+    std::io::Error::new(ErrorKind::Other, e)
+}
+
+impl AsyncWrite for Streaming {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        if self.pending_write {
+            return match self.stream.poll_ready(cx) {
+                Poll::Ready(Ok(())) => {
+                    self.pending_write = false;
+                    Poll::Ready(Ok(buf.len()))
+                }
+                Poll::Ready(Err(err)) => Poll::Ready(Err(to_std_err(err))),
+                Poll::Pending => Poll::Pending,
+            };
+        }
+        if let Err(err) = self.stream.push_data(Bytes::copy_from_slice(buf)) {
+            return Poll::Ready(Err(to_std_err(err)));
+        }
+        match self.stream.poll_ready(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(buf.len())),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(to_std_err(err))),
+            Poll::Pending => {
+                self.pending_write = true;
+                Poll::Pending
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        match self.stream.poll_shutdown(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(to_std_err(err))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl AsyncRead for Streaming {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if !self.pending_read.is_empty() {
+            self.copy_from_pending(buf);
+            return Poll::Ready(Ok(()));
+        }
+
+        match self.stream.poll_read(cx) {
+            Poll::Ready(Ok(Some(data))) => {
+                self.pending_read = Bytes::copy_from_slice(data.chunk());
+                self.copy_from_pending(buf);
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Ok(None)) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(to_std_err(e))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+async fn tx_write(mut tx: tokio::io::WriteHalf<Streaming>) {
+    let mut next = 0;
+    loop {
+        let send = format!("Client sequence {next}");
+        next += 1;
+        if let Err(err) = tx.write_all(send.as_bytes()).await {
+            info!(?err, "read error");
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+async fn rx_read(mut rx: tokio::io::ReadHalf<Streaming>) {
+    loop {
+        let mut buf = BytesMut::with_capacity(32);
+        if let Err(err) = rx.read_buf(&mut buf).await {
+            info!(?err, "read error");
+            break;
+        }
+        info!("data from server {:?}\n", String::from_utf8_lossy(&buf[..]));
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::FULL)
+        .with_writer(std::io::stderr)
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    let opt = Opt::from_args();
+
+    // DNS lookup
+
+    let uri = opt.uri.parse::<http::Uri>()?;
+
+    if uri.scheme() != Some(&http::uri::Scheme::HTTPS) {
+        Err("uri scheme must be 'https'")?;
+    }
+
+    let auth = uri.authority().ok_or("uri must have a host")?.clone();
+
+    let port = auth.port_u16().unwrap_or(443);
+
+    let addr = tokio::net::lookup_host((auth.host(), port))
+        .await?
+        .next()
+        .ok_or("dns found no addresses")?;
+
+    info!("DNS lookup for {:?}: {:?}", uri, addr);
+
+    // create quinn client endpoint
+
+    // load CA certificates stored in the system
+    let mut roots = rustls::RootCertStore::empty();
+    match rustls_native_certs::load_native_certs() {
+        Ok(certs) => {
+            for cert in certs {
+                if let Err(e) = roots.add(&rustls::Certificate(cert.0)) {
+                    error!("failed to parse trust anchor: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            error!("couldn't load any default trust roots: {}", e);
+        }
+    };
+
+    // load certificate of CA who issues the server certificate
+    // NOTE that this should be used for dev only
+    if let Err(e) = roots.add(&rustls::Certificate(std::fs::read(opt.ca)?)) {
+        error!("failed to parse trust anchor: {}", e);
+    }
+
+    let mut tls_config = rustls::ClientConfig::builder()
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(&[&rustls::version::TLS13])?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    tls_config.enable_early_data = true;
+    tls_config.alpn_protocols = vec![ALPN.into()];
+
+    // optional debugging support
+    if opt.key_log_file {
+        // Write all Keys to a file if SSLKEYLOGFILE is set
+        // WARNING, we enable this for the example, you should think carefully about enabling in your own code
+        tls_config.key_log = Arc::new(rustls::KeyLogFile::new());
+    }
+
+    let mut client_endpoint = h3_quinn::quinn::Endpoint::client("[::]:0".parse().unwrap())?;
+
+    let client_config = quinn::ClientConfig::new(Arc::new(tls_config));
+    client_endpoint.set_default_client_config(client_config);
+
+    let conn = client_endpoint.connect(addr, auth.host())?.await?;
+
+    info!("QUIC connection established");
+
+    // create h3 client
+
+    // h3 is designed to work with different QUIC implementations via
+    // a generic interface, that is, the [`quic::Connection`] trait.
+    // h3_quinn implements the trait w/ quinn to make it work with h3.
+    let quinn_conn = h3_quinn::Connection::new(conn);
+
+    let (mut driver, mut send_request) = h3::client::new(quinn_conn).await?;
+
+    let drive = async move {
+        future::poll_fn(|cx| driver.poll_close(cx)).await?;
+        Ok::<(), Box<dyn std::error::Error>>(())
+    };
+
+    // In the following block, we want to take ownership of `send_request`:
+    // the connection will be closed only when all `SendRequest`s instances
+    // are dropped.
+    let request = async move {
+        info!("sending request ...");
+        let req = http::Request::builder().uri(uri).body(())?;
+        let mut stream = send_request.send_request(req).await?;
+        info!("waiting for response ...");
+        let resp = stream.recv_response().await?;
+        info!("response: {:?}", resp);
+
+        // Now we convert the stream into a bidirectional stream
+        // of bytes which are AsyncRead/AsyncWrite
+        let streaming = Streaming::new(stream);
+        let (rx, tx) = tokio::io::split(streaming);
+
+        tokio::select! {
+            _ = tx_write(tx) => {},
+            _ = rx_read(rx) => {}
+        }
+
+        Ok::<_, Box<dyn std::error::Error>>(())
+    };
+
+    let (req_res, drive_res) = tokio::join!(request, drive);
+    req_res?;
+    drive_res?;
+
+    // wait for the connection to be closed before exiting
+    client_endpoint.wait_idle().await;
+
+    Ok(())
+}

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -53,3 +53,26 @@ Now you can navigate to files in the `root` folder for example `https://localhos
 The example [example client](client.rs) can generate a `SSLKEYLOGFILE` to see the traffic unencrypted in tools like Wireshark.  
 To set this up just set the `SSLKEYLOGFILE` environment variable to a file path and follow this [tutorial](https://wiki.wireshark.org/TLS#using-the-pre-master-secret).
 Then use the example client with the `--keylogfile=true` option to enable this.
+
+
+## Streaming client/serer - Start the client
+
+This example sends an HTTP request to the server, server responds with 
+a response and after that the client body and server body can be used
+as tokio AsyncRead/AsyncWrite streams to continue doing bidirectional
+data transfer on each end. In this example, the client sends a message
+every one second and server just echoes it back
+
+To start the streaming example client you can run following command:
+
+```bash
+> cargo run --example client_streaming -- https://localhost:4433
+```
+
+
+## Streaming client/server- start the server
+So that the server responds something you can provide a directory with content files.
+
+```bash
+> cargo run --example server_streaming -- --listen=127.0.0.1:4433 
+```

--- a/examples/server_streaming.rs
+++ b/examples/server_streaming.rs
@@ -1,0 +1,278 @@
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+
+use bytes::{Buf, Bytes, BytesMut};
+use http::StatusCode;
+use rustls::{Certificate, PrivateKey};
+use structopt::StructOpt;
+use tokio::io::AsyncReadExt;
+use tracing::{error, info, trace_span};
+
+use h3::{error::ErrorLevel, server::RequestStream};
+use h3_quinn::quinn;
+
+use std::io::ErrorKind;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+use tokio::io::ReadBuf;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "server")]
+struct Opt {
+    #[structopt(
+        short,
+        long,
+        default_value = "[::1]:4433",
+        help = "What address:port to listen for new connections"
+    )]
+    pub listen: SocketAddr,
+
+    #[structopt(flatten)]
+    pub certs: Certs,
+}
+
+#[derive(StructOpt, Debug)]
+pub struct Certs {
+    #[structopt(
+        long,
+        short,
+        default_value = "examples/server.cert",
+        help = "Certificate for TLS. If present, `--key` is mandatory."
+    )]
+    pub cert: PathBuf,
+
+    #[structopt(
+        long,
+        short,
+        default_value = "examples/server.key",
+        help = "Private key for the certificate."
+    )]
+    pub key: PathBuf,
+}
+
+static ALPN: &[u8] = b"h3";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::FULL)
+        .with_writer(std::io::stderr)
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    // process cli arguments
+
+    let opt = Opt::from_args();
+
+    let Certs { cert, key } = opt.certs;
+
+    // create quinn server endpoint and bind UDP socket
+
+    // both cert and key must be DER-encoded
+    let cert = Certificate(std::fs::read(cert)?);
+    let key = PrivateKey(std::fs::read(key)?);
+
+    let mut tls_config = rustls::ServerConfig::builder()
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert], key)?;
+
+    tls_config.max_early_data_size = u32::MAX;
+    tls_config.alpn_protocols = vec![ALPN.into()];
+
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(tls_config));
+    let endpoint = quinn::Endpoint::server(server_config, opt.listen)?;
+
+    info!("listening on {}", opt.listen);
+
+    // handle incoming connections and requests
+
+    while let Some(new_conn) = endpoint.accept().await {
+        trace_span!("New connection being attempted");
+
+        tokio::spawn(async move {
+            match new_conn.await {
+                Ok(conn) => {
+                    info!("new connection established");
+
+                    let mut h3_conn = h3::server::Connection::new(h3_quinn::Connection::new(conn))
+                        .await
+                        .unwrap();
+
+                    loop {
+                        match h3_conn.accept().await {
+                            Ok(Some((req, stream))) => {
+                                info!("new request: {:#?}", req);
+
+                                tokio::spawn(async move {
+                                    if let Err(e) = handle_request(stream).await {
+                                        error!("handling request failed: {}", e);
+                                    }
+                                });
+                            }
+
+                            // indicating no more streams to be received
+                            Ok(None) => {
+                                break;
+                            }
+
+                            Err(err) => {
+                                error!("error on accept {}", err);
+                                match err.get_error_level() {
+                                    ErrorLevel::ConnectionError => break,
+                                    ErrorLevel::StreamError => continue,
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    error!("accepting connection failed: {:?}", err);
+                }
+            }
+        });
+    }
+
+    // shut down gracefully
+    // wait for connections to be closed before exiting
+    endpoint.wait_idle().await;
+
+    Ok(())
+}
+
+pub struct Streaming {
+    stream: RequestStream<h3_quinn::BidiStream<Bytes>, Bytes>,
+    pending_read: Bytes,
+    pending_write: bool,
+}
+
+impl Streaming {
+    pub(crate) fn new(stream: RequestStream<h3_quinn::BidiStream<Bytes>, Bytes>) -> Self {
+        Self {
+            stream,
+            pending_read: Bytes::new(),
+            pending_write: false,
+        }
+    }
+
+    fn copy_from_pending(&mut self, copy_to: &mut ReadBuf<'_>) {
+        let copy = std::cmp::min(copy_to.remaining(), self.pending_read.len());
+        copy_to.put_slice(&self.pending_read[0..copy]);
+        self.pending_read.advance(copy);
+    }
+}
+
+fn to_std_err(e: h3::error::Error) -> std::io::Error {
+    std::io::Error::new(ErrorKind::Other, e)
+}
+
+impl AsyncWrite for Streaming {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        if self.pending_write {
+            return match self.stream.poll_ready(cx) {
+                Poll::Ready(Ok(())) => {
+                    self.pending_write = false;
+                    Poll::Ready(Ok(buf.len()))
+                }
+                Poll::Ready(Err(err)) => Poll::Ready(Err(to_std_err(err))),
+                Poll::Pending => Poll::Pending,
+            };
+        }
+        if let Err(err) = self.stream.push_data(Bytes::copy_from_slice(buf)) {
+            return Poll::Ready(Err(to_std_err(err)));
+        }
+        match self.stream.poll_ready(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(buf.len())),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(to_std_err(err))),
+            Poll::Pending => {
+                self.pending_write = true;
+                Poll::Pending
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        match self.stream.poll_shutdown(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(to_std_err(err))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl AsyncRead for Streaming {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if !self.pending_read.is_empty() {
+            self.copy_from_pending(buf);
+            return Poll::Ready(Ok(()));
+        }
+
+        match self.stream.poll_read(cx) {
+            Poll::Ready(Ok(Some(data))) => {
+                self.pending_read = Bytes::copy_from_slice(data.chunk());
+                self.copy_from_pending(buf);
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Ok(None)) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(to_std_err(e))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+async fn echo_service(mut streaming: Streaming) -> Result<(), Box<dyn std::error::Error>> {
+    loop {
+        let mut buf = BytesMut::with_capacity(32);
+        if let Err(err) = streaming.read_buf(&mut buf).await {
+            info!(?err, "read error");
+            return Err(err.into());
+        }
+        info!("data from client {:?}", String::from_utf8_lossy(&buf[..]));
+        if let Err(err) = streaming.write_all(&buf).await {
+            info!(?err, "write error");
+            return Err(err.into());
+        }
+    }
+}
+
+async fn handle_request(
+    mut stream: RequestStream<h3_quinn::BidiStream<Bytes>, Bytes>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let resp = http::Response::builder()
+        .status(StatusCode::OK)
+        .body(())
+        .unwrap();
+
+    match stream.send_response(resp).await {
+        Ok(_) => {
+            info!("successfully respond to connection");
+        }
+        Err(err) => {
+            error!("unable to send response to connection peer: {:?}", err);
+        }
+    }
+
+    let streaming = Streaming::new(stream);
+    echo_service(streaming).await
+}

--- a/h3/src/client.rs
+++ b/h3/src/client.rs
@@ -687,6 +687,11 @@ where
         self.inner.recv_data().await
     }
 
+    /// Poll some of the request body.
+    pub fn poll_read(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<impl Buf>, Error>> {
+        self.inner.poll_read(cx)
+    }
+
     /// Receive an optional set of trailers for the response.
     pub async fn recv_trailers(&mut self) -> Result<Option<HeaderMap>, Error> {
         let res = self.inner.recv_trailers().await;
@@ -716,6 +721,18 @@ where
         self.inner.send_data(buf).await
     }
 
+    /// push_data() will queue up data to be sent, it has to be followed by
+    /// polling for poll_ready() to actually transmit it. push_data() will
+    /// return error if there is already data queued up to be sent
+    pub fn push_data(&mut self, buf: B) -> Result<(), Error> {
+        self.inner.push_data(buf)
+    }
+
+    /// Ensures that the queued up data is transmitted
+    pub fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        self.inner.poll_ready(cx)
+    }
+
     /// Send a set of trailers to end the request.
     ///
     /// Either [`RequestStream::finish`] or
@@ -732,6 +749,11 @@ where
     /// request.
     pub async fn finish(&mut self) -> Result<(), Error> {
         self.inner.finish().await
+    }
+
+    /// Poll to finish the sending side of the stream
+    pub fn poll_shutdown(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        self.inner.poll_shutdown(cx)
     }
 
     //= https://www.rfc-editor.org/rfc/rfc9114#section-4.1.1

--- a/h3/src/server.rs
+++ b/h3/src/server.rs
@@ -674,6 +674,11 @@ where
         self.inner.recv_data().await
     }
 
+    /// Poll for data sent from the client
+    pub fn poll_read(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<impl Buf>, Error>> {
+        self.inner.poll_read(cx)
+    }
+
     /// Receive an optional set of trailers for the request
     pub async fn recv_trailers(&mut self) -> Result<Option<HeaderMap>, Error> {
         self.inner.recv_trailers().await
@@ -737,6 +742,18 @@ where
         self.inner.send_data(buf).await
     }
 
+    /// push_data() will queue up data to be sent, it has to be followed by
+    /// polling for poll_ready() to actually transmit it. push_data() will
+    /// return error if there is already data queued up to be sent
+    pub fn push_data(&mut self, buf: B) -> Result<(), Error> {
+        self.inner.push_data(buf)
+    }
+
+    /// Ensures that the queued up data is transmitted
+    pub fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        self.inner.poll_ready(cx)
+    }
+
     /// Stop a stream with an error code
     ///
     /// The code can be [`Code::H3_NO_ERROR`].
@@ -773,6 +790,11 @@ where
     /// Returns the underlying stream id
     pub fn send_id(&self) -> StreamId {
         self.inner.stream.send_id()
+    }
+
+    /// Poll to finish the sending side of the stream
+    pub fn poll_shutdown(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        self.inner.poll_shutdown(cx)
     }
 }
 


### PR DESCRIPTION
It is useful in certain applications to have poller apis exposed for equivalent of recv_data and send_data.

recv_data is being mapped to poll_read in this diff send_data is a combination of push_data and poll_ready