### PR TITLE
Make SendRequest Sync

### DIFF
--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -22,3 +22,4 @@ quinn-proto = { version = "0.10", default-features = false }
 tokio-util = { version = "0.7.9" }
 futures = { version = "0.3.28" }
 tokio = { version = "1", features = ["io-util"], default-features = false }
+sync_wrapper = "0.1.2"


### PR DESCRIPTION
SendRequest is clone-able and Send-able which is convenient for applications to store/embed SendRequest in their own structures and use that from different async tasks. This would also mean that if the application is sharing reference to their structures (that has a SendRequest inside) across tasks, then SendRequest would need to be Sync too. It will be really really convenient to have SendRequest as Sync or else the applications will basically have to wrap the SendRequest in Arc<Mutex<>>

SendRequest has the "open" element which implements OpenStreams, and these are basically Stream futures. Streams are not Sync, there is plenty of discussions on related topics in this link - https://internals.rust-lang.org/t/what-shall-sync-mean-across-an-await/1202

I am not exactly sure why the OpenStreams methods are implemented as futures that are stored in SendRequest, why cant they be implemented as open_foo() calls into the underlying quinn connection from the pollers in OpenStreams. I am assuming there is a good reason for that (which I am interested in learning), and hence if we want to retain these as stored futures, then basically I am doing a SyncWrap of those here