### PR TITLE
usize is pointer size dependant

### DIFF
--- a/h3/src/qpack/block.rs
+++ b/h3/src/qpack/block.rs
@@ -179,11 +179,15 @@ impl HeaderPrefix {
         let (sign_negative, delta_base) = prefix_int::decode(7, buf)?;
 
         if encoded_insert_count > (usize::MAX as u64) {
-            return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+            return Err(ParseError::Integer(
+                crate::qpack::prefix_int::Error::Overflow,
+            ));
         }
 
         if delta_base > (usize::MAX as u64) {
-            return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+            return Err(ParseError::Integer(
+                crate::qpack::prefix_int::Error::Overflow,
+            ));
         }
 
         Ok(Self {
@@ -211,18 +215,22 @@ impl Indexed {
         match prefix_int::decode(6, buf)? {
             (0b11, i) => {
                 if i > (usize::MAX as u64) {
-                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                    return Err(ParseError::Integer(
+                        crate::qpack::prefix_int::Error::Overflow,
+                    ));
                 }
 
                 Ok(Indexed::Static(i as usize))
-            },
+            }
             (0b10, i) => {
                 if i > (usize::MAX as u64) {
-                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                    return Err(ParseError::Integer(
+                        crate::qpack::prefix_int::Error::Overflow,
+                    ));
                 }
 
                 Ok(Indexed::Dynamic(i as usize))
-            },
+            }
             (f, _) => Err(ParseError::InvalidPrefix(f)),
         }
     }
@@ -243,11 +251,13 @@ impl IndexedWithPostBase {
         match prefix_int::decode(4, buf)? {
             (0b0001, i) => {
                 if i > (usize::MAX as u64) {
-                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                    return Err(ParseError::Integer(
+                        crate::qpack::prefix_int::Error::Overflow,
+                    ));
                 }
 
                 Ok(IndexedWithPostBase(i as usize))
-            },
+            }
             (f, _) => Err(ParseError::InvalidPrefix(f)),
         }
     }
@@ -282,22 +292,28 @@ impl LiteralWithNameRef {
         match prefix_int::decode(4, buf)? {
             (f, i) if f & 0b0101 == 0b0101 => {
                 if i > (usize::MAX as u64) {
-                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                    return Err(ParseError::Integer(
+                        crate::qpack::prefix_int::Error::Overflow,
+                    ));
                 }
 
                 Ok(LiteralWithNameRef::new_static(
-                i as usize,
-                prefix_string::decode(8, buf)?))
-            },
+                    i as usize,
+                    prefix_string::decode(8, buf)?,
+                ))
+            }
             (f, i) if f & 0b0101 == 0b0100 => {
                 if i > (usize::MAX as u64) {
-                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                    return Err(ParseError::Integer(
+                        crate::qpack::prefix_int::Error::Overflow,
+                    ));
                 }
 
                 Ok(LiteralWithNameRef::new_dynamic(
-                i as usize,
-                prefix_string::decode(8, buf)?))
-            },
+                    i as usize,
+                    prefix_string::decode(8, buf)?,
+                ))
+            }
             (f, _) => Err(ParseError::InvalidPrefix(f)),
         }
     }
@@ -335,13 +351,16 @@ impl LiteralWithPostBaseNameRef {
         match prefix_int::decode(3, buf)? {
             (f, i) if f & 0b1111_0000 == 0 => {
                 if i > (usize::MAX as u64) {
-                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                    return Err(ParseError::Integer(
+                        crate::qpack::prefix_int::Error::Overflow,
+                    ));
                 }
 
                 Ok(LiteralWithPostBaseNameRef::new(
-                i as usize,
-                prefix_string::decode(8, buf)?))
-            },
+                    i as usize,
+                    prefix_string::decode(8, buf)?,
+                ))
+            }
             (f, _) => Err(ParseError::InvalidPrefix(f)),
         }
     }

--- a/h3/src/qpack/block.rs
+++ b/h3/src/qpack/block.rs
@@ -177,17 +177,26 @@ impl HeaderPrefix {
     pub fn decode<R: Buf>(buf: &mut R) -> Result<Self, ParseError> {
         let (_, encoded_insert_count) = prefix_int::decode(8, buf)?;
         let (sign_negative, delta_base) = prefix_int::decode(7, buf)?;
+
+        if encoded_insert_count > (usize::MAX as u64) {
+            return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+        }
+
+        if delta_base > (usize::MAX as u64) {
+            return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+        }
+
         Ok(Self {
-            encoded_insert_count,
-            delta_base,
+            encoded_insert_count: encoded_insert_count as usize,
+            delta_base: delta_base as usize,
             sign_negative: sign_negative == 1,
         })
     }
 
     pub fn encode<W: BufMut>(&self, buf: &mut W) {
         let sign_bit = if self.sign_negative { 1 } else { 0 };
-        prefix_int::encode(8, 0, self.encoded_insert_count, buf);
-        prefix_int::encode(7, sign_bit, self.delta_base, buf);
+        prefix_int::encode(8, 0, self.encoded_insert_count as u64, buf);
+        prefix_int::encode(7, sign_bit, self.delta_base as u64, buf);
     }
 }
 
@@ -200,16 +209,28 @@ pub enum Indexed {
 impl Indexed {
     pub fn decode<R: Buf>(buf: &mut R) -> Result<Self, ParseError> {
         match prefix_int::decode(6, buf)? {
-            (0b11, i) => Ok(Indexed::Static(i)),
-            (0b10, i) => Ok(Indexed::Dynamic(i)),
+            (0b11, i) => {
+                if i > (usize::MAX as u64) {
+                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                }
+
+                Ok(Indexed::Static(i as usize))
+            },
+            (0b10, i) => {
+                if i > (usize::MAX as u64) {
+                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                }
+
+                Ok(Indexed::Dynamic(i as usize))
+            },
             (f, _) => Err(ParseError::InvalidPrefix(f)),
         }
     }
 
     pub fn encode<W: BufMut>(&self, buf: &mut W) {
         match self {
-            Indexed::Static(i) => prefix_int::encode(6, 0b11, *i, buf),
-            Indexed::Dynamic(i) => prefix_int::encode(6, 0b10, *i, buf),
+            Indexed::Static(i) => prefix_int::encode(6, 0b11, *i as u64, buf),
+            Indexed::Dynamic(i) => prefix_int::encode(6, 0b10, *i as u64, buf),
         }
     }
 }
@@ -220,13 +241,19 @@ pub struct IndexedWithPostBase(pub usize);
 impl IndexedWithPostBase {
     pub fn decode<R: Buf>(buf: &mut R) -> Result<Self, ParseError> {
         match prefix_int::decode(4, buf)? {
-            (0b0001, i) => Ok(IndexedWithPostBase(i)),
+            (0b0001, i) => {
+                if i > (usize::MAX as u64) {
+                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                }
+
+                Ok(IndexedWithPostBase(i as usize))
+            },
             (f, _) => Err(ParseError::InvalidPrefix(f)),
         }
     }
 
     pub fn encode<W: BufMut>(&self, buf: &mut W) {
-        prefix_int::encode(4, 0b0001, self.0, buf)
+        prefix_int::encode(4, 0b0001, self.0 as u64, buf)
     }
 }
 
@@ -253,14 +280,24 @@ impl LiteralWithNameRef {
 
     pub fn decode<R: Buf>(buf: &mut R) -> Result<Self, ParseError> {
         match prefix_int::decode(4, buf)? {
-            (f, i) if f & 0b0101 == 0b0101 => Ok(LiteralWithNameRef::new_static(
-                i,
-                prefix_string::decode(8, buf)?,
-            )),
-            (f, i) if f & 0b0101 == 0b0100 => Ok(LiteralWithNameRef::new_dynamic(
-                i,
-                prefix_string::decode(8, buf)?,
-            )),
+            (f, i) if f & 0b0101 == 0b0101 => {
+                if i > (usize::MAX as u64) {
+                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                }
+
+                Ok(LiteralWithNameRef::new_static(
+                i as usize,
+                prefix_string::decode(8, buf)?))
+            },
+            (f, i) if f & 0b0101 == 0b0100 => {
+                if i > (usize::MAX as u64) {
+                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                }
+
+                Ok(LiteralWithNameRef::new_dynamic(
+                i as usize,
+                prefix_string::decode(8, buf)?))
+            },
             (f, _) => Err(ParseError::InvalidPrefix(f)),
         }
     }
@@ -268,11 +305,11 @@ impl LiteralWithNameRef {
     pub fn encode<W: BufMut>(&self, buf: &mut W) -> Result<(), prefix_string::Error> {
         match self {
             LiteralWithNameRef::Static { index, value } => {
-                prefix_int::encode(4, 0b0101, *index, buf);
+                prefix_int::encode(4, 0b0101, *index as u64, buf);
                 prefix_string::encode(8, 0, value, buf)?;
             }
             LiteralWithNameRef::Dynamic { index, value } => {
-                prefix_int::encode(4, 0b0100, *index, buf);
+                prefix_int::encode(4, 0b0100, *index as u64, buf);
                 prefix_string::encode(8, 0, value, buf)?;
             }
         }
@@ -296,16 +333,21 @@ impl LiteralWithPostBaseNameRef {
 
     pub fn decode<R: Buf>(buf: &mut R) -> Result<Self, ParseError> {
         match prefix_int::decode(3, buf)? {
-            (f, i) if f & 0b1111_0000 == 0 => Ok(LiteralWithPostBaseNameRef::new(
-                i,
-                prefix_string::decode(8, buf)?,
-            )),
+            (f, i) if f & 0b1111_0000 == 0 => {
+                if i > (usize::MAX as u64) {
+                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                }
+
+                Ok(LiteralWithPostBaseNameRef::new(
+                i as usize,
+                prefix_string::decode(8, buf)?))
+            },
             (f, _) => Err(ParseError::InvalidPrefix(f)),
         }
     }
 
     pub fn encode<W: BufMut>(&self, buf: &mut W) -> Result<(), prefix_string::Error> {
-        prefix_int::encode(3, 0b0000, self.index, buf);
+        prefix_int::encode(3, 0b0000, self.index as u64, buf);
         prefix_string::encode(8, 0, &self.value, buf)?;
         Ok(())
     }
@@ -347,6 +389,7 @@ impl Literal {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::convert::TryInto;
     use std::io::Cursor;
 
     const TABLE_SIZE: usize = 4096;
@@ -424,7 +467,7 @@ mod test {
     #[test]
     fn base_index_too_small() {
         let mut buf = vec![];
-        let encoded_largest_ref = (2 % (2 * TABLE_SIZE / 32)) + 1;
+        let encoded_largest_ref: u64 = ((2 % (2 * TABLE_SIZE / 32)) + 1).try_into().unwrap();
         prefix_int::encode(8, 0, encoded_largest_ref, &mut buf);
         prefix_int::encode(7, 1, 2, &mut buf); // base index negative = 0
 

--- a/h3/src/qpack/decoder.rs
+++ b/h3/src/qpack/decoder.rs
@@ -128,7 +128,8 @@ impl Decoder {
         }
 
         if self.table.total_inserted() != inserted_on_start {
-            InsertCountIncrement((self.table.total_inserted() - inserted_on_start).try_into()?).encode(write);
+            InsertCountIncrement((self.table.total_inserted() - inserted_on_start).try_into()?)
+                .encode(write);
         }
 
         Ok(self.table.total_inserted())

--- a/h3/src/qpack/decoder.rs
+++ b/h3/src/qpack/decoder.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use std::{fmt, io::Cursor};
+use std::{convert::TryInto, fmt, io::Cursor, num::TryFromIntError};
 
 use tracing::trace;
 
@@ -36,6 +36,7 @@ pub enum Error {
     BadBaseIndex(isize),
     UnexpectedEnd,
     HeaderTooLong(u64),
+    BufSize(TryFromIntError),
 }
 
 impl std::error::Error for Error {}
@@ -53,6 +54,7 @@ impl std::fmt::Display for Error {
             Error::BadBaseIndex(i) => write!(f, "out of bounds base index: {}", i),
             Error::UnexpectedEnd => write!(f, "unexpected end"),
             Error::HeaderTooLong(_) => write!(f, "header too long"),
+            Error::BufSize(_) => write!(f, "number in buffer wrong size"),
         }
     }
 }
@@ -126,7 +128,7 @@ impl Decoder {
         }
 
         if self.table.total_inserted() != inserted_on_start {
-            InsertCountIncrement(self.table.total_inserted() - inserted_on_start).encode(write);
+            InsertCountIncrement((self.table.total_inserted() - inserted_on_start).try_into()?).encode(write);
         }
 
         Ok(self.table.total_inserted())
@@ -323,6 +325,12 @@ impl From<ParseError> for Error {
             ParseError::InvalidPrefix(p) => Error::UnknownPrefix(p),
             ParseError::InvalidBase(b) => Error::BadBaseIndex(b),
         }
+    }
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(error: TryFromIntError) -> Self {
+        Error::BufSize(error)
     }
 }
 

--- a/h3/src/qpack/encoder.rs
+++ b/h3/src/qpack/encoder.rs
@@ -239,9 +239,8 @@ impl Action {
         let first = buf.chunk()[0];
         let instruction = match DecoderInstruction::decode(first) {
             DecoderInstruction::Unknown => return Err(Error::UnknownDecoderInstruction(first)),
-            DecoderInstruction::InsertCountIncrement => {
-                InsertCountIncrement::decode(&mut buf)?.map(|x| Action::ReceivedRefIncrement(x.0 as usize))
-            }
+            DecoderInstruction::InsertCountIncrement => InsertCountIncrement::decode(&mut buf)?
+                .map(|x| Action::ReceivedRefIncrement(x.0 as usize)),
             DecoderInstruction::HeaderAck => {
                 HeaderAck::decode(&mut buf)?.map(|x| Action::Untrack(x.0))
             }

--- a/h3/src/qpack/encoder.rs
+++ b/h3/src/qpack/encoder.rs
@@ -240,7 +240,7 @@ impl Action {
         let instruction = match DecoderInstruction::decode(first) {
             DecoderInstruction::Unknown => return Err(Error::UnknownDecoderInstruction(first)),
             DecoderInstruction::InsertCountIncrement => {
-                InsertCountIncrement::decode(&mut buf)?.map(|x| Action::ReceivedRefIncrement(x.0))
+                InsertCountIncrement::decode(&mut buf)?.map(|x| Action::ReceivedRefIncrement(x.0 as usize))
             }
             DecoderInstruction::HeaderAck => {
                 HeaderAck::decode(&mut buf)?.map(|x| Action::Untrack(x.0))

--- a/h3/src/qpack/prefix_int.rs
+++ b/h3/src/qpack/prefix_int.rs
@@ -19,7 +19,7 @@ impl std::fmt::Display for Error {
     }
 }
 
-pub fn decode<B: Buf>(size: u8, buf: &mut B) -> Result<(u8, usize), Error> {
+pub fn decode<B: Buf>(size: u8, buf: &mut B) -> Result<(u8, u64), Error> {
     assert!(size <= 8);
     let mut first = buf.get::<u8>()?;
 
@@ -31,13 +31,13 @@ pub fn decode<B: Buf>(size: u8, buf: &mut B) -> Result<(u8, usize), Error> {
 
     // if first < 2usize.pow(size) - 1
     if first < mask {
-        return Ok((flags, first as usize));
+        return Ok((flags, first as u64));
     }
 
-    let mut value = mask as usize;
+    let mut value = mask as u64;
     let mut power = 0usize;
     loop {
-        let byte = buf.get::<u8>()? as usize;
+        let byte = buf.get::<u8>()? as u64;
         value += (byte & 127) << power;
         power += 7;
 
@@ -53,7 +53,7 @@ pub fn decode<B: Buf>(size: u8, buf: &mut B) -> Result<(u8, usize), Error> {
     Ok((flags, value))
 }
 
-pub fn encode<B: BufMut>(size: u8, flags: u8, value: usize, buf: &mut B) {
+pub fn encode<B: BufMut>(size: u8, flags: u8, value: u64, buf: &mut B) {
     assert!(size <= 8);
     // NOTE: following casts to u8 intend to trim the most significant bits, they are used as a
     //       workaround for shiftoverflow errors when size == 8.
@@ -61,13 +61,13 @@ pub fn encode<B: BufMut>(size: u8, flags: u8, value: usize, buf: &mut B) {
     let flags = ((flags as usize) << size) as u8;
 
     // if value < 2usize.pow(size) - 1
-    if value < (mask as usize) {
+    if value < (mask as u64) {
         buf.write(flags | value as u8);
         return;
     }
 
     buf.write(mask | flags);
-    let mut remaining = value - mask as usize;
+    let mut remaining = value - mask as u64;
 
     while remaining >= 128 {
         let rest = (remaining % 128) as u8;
@@ -93,7 +93,7 @@ impl From<coding::UnexpectedEnd> for Error {
 mod test {
     use std::io::Cursor;
 
-    fn check_codec(size: u8, flags: u8, value: usize, data: &[u8]) {
+    fn check_codec(size: u8, flags: u8, value: u64, data: &[u8]) {
         let mut buf = Vec::new();
         super::encode(size, flags, value, &mut buf);
         assert_eq!(buf, data);
@@ -107,19 +107,11 @@ mod test {
         check_codec(5, 0b101, 0, &[0b1010_0000]);
         check_codec(5, 0b010, 1337, &[0b0101_1111, 154, 10]);
         check_codec(5, 0b010, 31, &[0b0101_1111, 0]);
-        #[cfg(target_pointer_width = "64")]
         check_codec(
             5,
             0b010,
-            usize::max_value(),
+            u64::max_value(),
             &[95, 224, 255, 255, 255, 255, 255, 255, 255, 255, 1],
-        );
-        #[cfg(target_pointer_width = "32")]
-        check_codec(
-            5,
-            0b010,
-            usize::max_value(),
-            &[95, 224, 255, 255, 255, 15],
         );
     }
 
@@ -127,19 +119,11 @@ mod test {
     fn codec_8_bits() {
         check_codec(8, 0, 42, &[0b0010_1010]);
         check_codec(8, 0, 424_242, &[255, 179, 240, 25]);
-        #[cfg(target_pointer_width = "64")]
         check_codec(
             8,
             0,
-            usize::max_value(),
+            u64::max_value(),
             &[255, 128, 254, 255, 255, 255, 255, 255, 255, 255, 1],
-        );
-        #[cfg(target_pointer_width = "32")]
-        check_codec(
-            8,
-            0,
-            usize::max_value(),
-            &[255, 128, 254, 255, 255, 15],
         );
     }
 

--- a/h3/src/qpack/prefix_int.rs
+++ b/h3/src/qpack/prefix_int.rs
@@ -107,11 +107,19 @@ mod test {
         check_codec(5, 0b101, 0, &[0b1010_0000]);
         check_codec(5, 0b010, 1337, &[0b0101_1111, 154, 10]);
         check_codec(5, 0b010, 31, &[0b0101_1111, 0]);
+        #[cfg(target_pointer_width = "64")]
         check_codec(
             5,
             0b010,
             usize::max_value(),
             &[95, 224, 255, 255, 255, 255, 255, 255, 255, 255, 1],
+        );
+        #[cfg(target_pointer_width = "32")]
+        check_codec(
+            5,
+            0b010,
+            usize::max_value(),
+            &[95, 224, 255, 255, 255, 15],
         );
     }
 
@@ -119,11 +127,19 @@ mod test {
     fn codec_8_bits() {
         check_codec(8, 0, 42, &[0b0010_1010]);
         check_codec(8, 0, 424_242, &[255, 179, 240, 25]);
+        #[cfg(target_pointer_width = "64")]
         check_codec(
             8,
             0,
             usize::max_value(),
             &[255, 128, 254, 255, 255, 255, 255, 255, 255, 255, 1],
+        );
+        #[cfg(target_pointer_width = "32")]
+        check_codec(
+            8,
+            0,
+            usize::max_value(),
+            &[255, 128, 254, 255, 255, 15],
         );
     }
 

--- a/h3/src/qpack/prefix_string/mod.rs
+++ b/h3/src/qpack/prefix_string/mod.rs
@@ -2,7 +2,9 @@ mod bitwin;
 mod decode;
 mod encode;
 
+use std::convert::TryInto;
 use std::fmt;
+use std::num::TryFromIntError;
 
 use bytes::{Buf, BufMut};
 
@@ -22,6 +24,7 @@ pub enum Error {
     Integer(IntegerError),
     HuffmanDecoding(HuffmanDecodingError),
     HuffmanEncoding(HuffmanEncodingError),
+    BufSize(TryFromIntError),
 }
 
 impl std::fmt::Display for Error {
@@ -31,12 +34,14 @@ impl std::fmt::Display for Error {
             Error::Integer(e) => write!(f, "could not parse integer: {}", e),
             Error::HuffmanDecoding(e) => write!(f, "Huffman decode failed: {:?}", e),
             Error::HuffmanEncoding(e) => write!(f, "Huffman encode failed: {:?}", e),
+            Error::BufSize(_) => write!(f, "number in buffer wrong size"),
         }
     }
 }
 
 pub fn decode<B: Buf>(size: u8, buf: &mut B) -> Result<Vec<u8>, Error> {
     let (flags, len) = prefix_int::decode(size - 1, buf)?;
+    let len: usize = len.try_into()?;
     if buf.remaining() < len {
         return Err(Error::UnexpectedEnd);
     }
@@ -56,7 +61,7 @@ pub fn decode<B: Buf>(size: u8, buf: &mut B) -> Result<Vec<u8>, Error> {
 
 pub fn encode<B: BufMut>(size: u8, flags: u8, value: &[u8], buf: &mut B) -> Result<(), Error> {
     let encoded = Vec::from(value).hpack_encode()?;
-    prefix_int::encode(size - 1, flags << 1 | 1, encoded.len(), buf);
+    prefix_int::encode(size - 1, flags << 1 | 1, encoded.len().try_into()?, buf);
     for byte in encoded {
         buf.write(byte);
     }
@@ -81,6 +86,12 @@ impl From<IntegerError> for Error {
 impl From<HuffmanDecodingError> for Error {
     fn from(error: HuffmanDecodingError) -> Self {
         Error::HuffmanDecoding(error)
+    }
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(error: TryFromIntError) -> Self {
+        Error::BufSize(error)
     }
 }
 

--- a/h3/src/qpack/stream.rs
+++ b/h3/src/qpack/stream.rs
@@ -97,7 +97,9 @@ impl InsertWithNameRef {
             Err(IntError::UnexpectedEnd) => return Ok(None),
             Err(e) => return Err(e.into()),
         };
-        let index: usize = index.try_into().map_err(|e| ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))?;
+        let index: usize = index
+            .try_into()
+            .map_err(|e| ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))?;
 
         let value = match prefix_string::decode(8, buf) {
             Ok(x) => x,
@@ -170,10 +172,12 @@ impl Duplicate {
         let index = match prefix_int::decode(5, buf) {
             Ok((0, x)) => {
                 if x > (usize::MAX as u64) {
-                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                    return Err(ParseError::Integer(
+                        crate::qpack::prefix_int::Error::Overflow,
+                    ));
                 }
                 x as usize
-            },
+            }
             Ok((f, _)) => return Err(ParseError::InvalidPrefix(f)),
             Err(IntError::UnexpectedEnd) => return Ok(None),
             Err(e) => return Err(e.into()),
@@ -194,10 +198,12 @@ impl DynamicTableSizeUpdate {
         let size = match prefix_int::decode(5, buf) {
             Ok((0b001, x)) => {
                 if x > (usize::MAX as u64) {
-                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                    return Err(ParseError::Integer(
+                        crate::qpack::prefix_int::Error::Overflow,
+                    ));
                 }
                 x as usize
-            },
+            }
             Ok((f, _)) => return Err(ParseError::InvalidPrefix(f)),
             Err(IntError::UnexpectedEnd) => return Ok(None),
             Err(e) => return Err(e.into()),
@@ -264,10 +270,12 @@ impl InsertCountIncrement {
         let insert_count = match prefix_int::decode(6, buf) {
             Ok((0b00, x)) => {
                 if x > 64 {
-                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                    return Err(ParseError::Integer(
+                        crate::qpack::prefix_int::Error::Overflow,
+                    ));
                 }
                 x as u8
-            },
+            }
             Ok((f, _)) => return Err(ParseError::InvalidPrefix(f)),
             Err(IntError::UnexpectedEnd) => return Ok(None),
             Err(e) => return Err(e.into()),

--- a/h3/src/qpack/stream.rs
+++ b/h3/src/qpack/stream.rs
@@ -1,4 +1,5 @@
 use bytes::{Buf, BufMut};
+use std::convert::TryInto;
 
 use super::{
     parse_error::ParseError,
@@ -96,6 +97,7 @@ impl InsertWithNameRef {
             Err(IntError::UnexpectedEnd) => return Ok(None),
             Err(e) => return Err(e.into()),
         };
+        let index: usize = index.try_into().map_err(|e| ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))?;
 
         let value = match prefix_string::decode(8, buf) {
             Ok(x) => x,
@@ -113,11 +115,11 @@ impl InsertWithNameRef {
     pub fn encode<W: BufMut>(&self, buf: &mut W) -> Result<(), prefix_string::Error> {
         match self {
             InsertWithNameRef::Static { index, value } => {
-                prefix_int::encode(6, 0b11, *index, buf);
+                prefix_int::encode(6, 0b11, *index as u64, buf);
                 prefix_string::encode(8, 0, value, buf)?;
             }
             InsertWithNameRef::Dynamic { index, value } => {
-                prefix_int::encode(6, 0b10, *index, buf);
+                prefix_int::encode(6, 0b10, *index as u64, buf);
                 prefix_string::encode(8, 0, value, buf)?;
             }
         }
@@ -166,7 +168,12 @@ pub struct Duplicate(pub usize);
 impl Duplicate {
     pub fn decode<R: Buf>(buf: &mut R) -> Result<Option<Self>, ParseError> {
         let index = match prefix_int::decode(5, buf) {
-            Ok((0, x)) => x,
+            Ok((0, x)) => {
+                if x > (usize::MAX as u64) {
+                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                }
+                x as usize
+            },
             Ok((f, _)) => return Err(ParseError::InvalidPrefix(f)),
             Err(IntError::UnexpectedEnd) => return Ok(None),
             Err(e) => return Err(e.into()),
@@ -175,7 +182,7 @@ impl Duplicate {
     }
 
     pub fn encode<W: BufMut>(&self, buf: &mut W) {
-        prefix_int::encode(5, 0, self.0, buf);
+        prefix_int::encode(5, 0, self.0 as u64, buf);
     }
 }
 
@@ -185,7 +192,12 @@ pub struct DynamicTableSizeUpdate(pub usize);
 impl DynamicTableSizeUpdate {
     pub fn decode<R: Buf>(buf: &mut R) -> Result<Option<Self>, ParseError> {
         let size = match prefix_int::decode(5, buf) {
-            Ok((0b001, x)) => x,
+            Ok((0b001, x)) => {
+                if x > (usize::MAX as u64) {
+                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                }
+                x as usize
+            },
             Ok((f, _)) => return Err(ParseError::InvalidPrefix(f)),
             Err(IntError::UnexpectedEnd) => return Ok(None),
             Err(e) => return Err(e.into()),
@@ -194,7 +206,7 @@ impl DynamicTableSizeUpdate {
     }
 
     pub fn encode<W: BufMut>(&self, buf: &mut W) {
-        prefix_int::encode(5, 0b001, self.0, buf);
+        prefix_int::encode(5, 0b001, self.0 as u64, buf);
     }
 }
 
@@ -245,12 +257,17 @@ impl DecoderInstruction {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct InsertCountIncrement(pub usize);
+pub struct InsertCountIncrement(pub u8);
 
 impl InsertCountIncrement {
     pub fn decode<R: Buf>(buf: &mut R) -> Result<Option<Self>, ParseError> {
         let insert_count = match prefix_int::decode(6, buf) {
-            Ok((0b00, x)) => x,
+            Ok((0b00, x)) => {
+                if x > 64 {
+                    return Err(ParseError::Integer(crate::qpack::prefix_int::Error::Overflow))
+                }
+                x as u8
+            },
             Ok((f, _)) => return Err(ParseError::InvalidPrefix(f)),
             Err(IntError::UnexpectedEnd) => return Ok(None),
             Err(e) => return Err(e.into()),
@@ -259,7 +276,7 @@ impl InsertCountIncrement {
     }
 
     pub fn encode<W: BufMut>(&self, buf: &mut W) {
-        prefix_int::encode(6, 0b00, self.0, buf);
+        prefix_int::encode(6, 0b00, self.0 as u64, buf);
     }
 }
 
@@ -278,7 +295,7 @@ impl HeaderAck {
     }
 
     pub fn encode<W: BufMut>(&self, buf: &mut W) {
-        prefix_int::encode(7, 0b1, self.0 as usize, buf);
+        prefix_int::encode(7, 0b1, self.0, buf);
     }
 }
 
@@ -297,7 +314,7 @@ impl StreamCancel {
     }
 
     pub fn encode<W: BufMut>(&self, buf: &mut W) {
-        prefix_int::encode(6, 0b01, self.0 as usize, buf);
+        prefix_int::encode(6, 0b01, self.0, buf);
     }
 }
 


### PR DESCRIPTION
The unit tests are currently not working on 32-bit platforms: https://qa.debian.org/excuses.php?package=rust-h3

result without this patch:

```
failures:

---- qpack::prefix_int::test::codec_5_bits stdout ----
thread 'qpack::prefix_int::test::codec_5_bits' panicked at 'assertion failed: `(left == right)`
  left: `[95, 224, 255, 255, 255, 15]`,
 right: `[95, 224, 255, 255, 255, 255, 255, 255, 255, 255, 1]`', h3/src/qpack/prefix_int.rs:99:9

---- qpack::prefix_int::test::codec_8_bits stdout ----
thread 'qpack::prefix_int::test::codec_8_bits' panicked at 'assertion failed: `(left == right)`
  left: `[255, 128, 254, 255, 255, 15]`,
 right: `[255, 128, 254, 255, 255, 255, 255, 255, 255, 255, 1]`', h3/src/qpack/prefix_int.rs:99:9


failures:
    qpack::prefix_int::test::codec_5_bits
    qpack::prefix_int::test::codec_8_bits

test result: FAILED. 220 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.41s
```