### PR TITLE
Ensure field names do not contain uppercase

### DIFF
--- a/ci/compliance/specs/rfc9114/todo/4.2.toml
+++ b/ci/compliance/specs/rfc9114/todo/4.2.toml
@@ -2,13 +2,6 @@ target = "https://www.rfc-editor.org/rfc/rfc9114#section-4.2"
 
 [[TODO]]
 quote = '''
-A request or
-response containing uppercase characters in field names MUST be
-treated as malformed.
-'''
-
-[[TODO]]
-quote = '''
 An endpoint MUST NOT generate
 an HTTP/3 field section containing connection-specific fields; any
 message containing connection-specific fields MUST be treated as

--- a/h3/src/proto/headers.rs
+++ b/h3/src/proto/headers.rs
@@ -275,9 +275,15 @@ impl Field {
         //# character not permitted in a field value MUST be treated as
         //# malformed.
 
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-4.2
+        //= type=implication
+        //# A request or
+        //# response containing uppercase characters in field names MUST be
+        //# treated as malformed.
+
         if name[0] != b':' {
             return Ok(Field::Header((
-                HeaderName::from_bytes(name).map_err(|_| HeaderError::invalid_name(name))?,
+                HeaderName::from_lowercase(name).map_err(|_| HeaderError::invalid_name(name))?,
                 HeaderValue::from_bytes(value.as_ref())
                     .map_err(|_| HeaderError::invalid_value(name, value))?,
             )));


### PR DESCRIPTION
I classify this as implication because the http crate is responsible for ensuring HeaderName::from_lowercase throws an error when it encounters uppercase characters