### PR TITLE
use async fn in traits in `SendStream`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [
     "h3",
     "h3-quinn",
-    "h3-webtransport",
+  #  "h3-webtransport",
 
     # Internal
     "examples",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -47,6 +47,6 @@ path = "client.rs"
 name = "server"
 path = "server.rs"
 
-[[example]]
-name = "webtransport_server"
-path = "webtransport_server.rs"
+# [[example]]
+# name = "webtransport_server"
+# path = "webtransport_server.rs"

--- a/examples/webtransport_server.rs
+++ b/examples/webtransport_server.rs
@@ -278,7 +278,7 @@ where
         + h3::quic::Connection<Bytes>
         + RecvDatagramExt<Buf = Bytes>
         + SendDatagramExt<Bytes>,
-    <C::SendStream as h3::quic::SendStream<Bytes>>::Error:
+    <C::SendStream as h3::quic::SendStreamLocal<Bytes>>::Error:
         'static + std::error::Error + Send + Sync + Into<std::io::Error>,
     <C::RecvStream as h3::quic::RecvStream>::Error:
         'static + std::error::Error + Send + Sync + Into<std::io::Error>,

--- a/h3-webtransport/src/lib.rs
+++ b/h3-webtransport/src/lib.rs
@@ -5,9 +5,9 @@
 //! WebTransport over HTTP/3: <https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/>
 #![deny(missing_docs)]
 
-/// Server side WebTransport session support
-pub mod server;
-/// Webtransport stream types
-pub mod stream;
+// Server side WebTransport session support
+//pub mod server;
+// Webtransport stream types
+//pub mod stream;
 
-pub use h3::webtransport::SessionId;
+//pub use h3::webtransport::SessionId;

--- a/h3-webtransport/src/server.rs
+++ b/h3-webtransport/src/server.rs
@@ -39,7 +39,7 @@ use crate::stream::{BidiStream, RecvStream, SendStream};
 pub struct WebTransportSession<C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     // See: https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-2-3
     session_id: SessionId,
@@ -52,7 +52,7 @@ where
 impl<C, B> WebTransportSession<C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     /// Accepts a *CONNECT* request for establishing a WebTransport session.
     ///
@@ -273,7 +273,7 @@ pin_project! {
 impl<'a, B, C> Future for OpenBi<'a, C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
     C::BidiStream: SendStreamUnframed<B>,
 {
     type Output = Result<BidiStream<C::BidiStream, B>, Error>;
@@ -317,7 +317,7 @@ pin_project! {
 impl<'a, C, B> Future for OpenUni<'a, C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
     C::SendStream: SendStreamUnframed<B>,
 {
     type Output = Result<SendStream<C::SendStream, B>, Error>;
@@ -364,7 +364,7 @@ pub enum AcceptedBi<C: quic::Connection<B>, B: Buf> {
 pub struct ReadDatagram<'a, C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     conn: &'a Mutex<Connection<C, B>>,
     _marker: PhantomData<B>,
@@ -373,7 +373,7 @@ where
 impl<'a, C, B> Future for ReadDatagram<'a, C, B>
 where
     C: quic::Connection<B> + RecvDatagramExt,
-    B: Buf,
+    B: Buf + Send,
 {
     type Output = Result<Option<(SessionId, C::Buf)>, Error>;
 
@@ -396,7 +396,7 @@ where
 pub struct AcceptUni<'a, C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     conn: &'a Mutex<Connection<C, B>>,
 }
@@ -404,7 +404,7 @@ where
 impl<'a, C, B> Future for AcceptUni<'a, C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     type Output = Result<Option<(SessionId, RecvStream<C::RecvStream, B>)>, Error>;
 

--- a/h3-webtransport/src/stream.rs
+++ b/h3-webtransport/src/stream.rs
@@ -99,7 +99,7 @@ impl<S, B> SendStream<S, B> {
 impl<S, B> quic::SendStreamUnframed<B> for SendStream<S, B>
 where
     S: quic::SendStreamUnframed<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     fn poll_send<D: Buf>(
         &mut self,
@@ -113,7 +113,7 @@ where
 impl<S, B> quic::SendStream<B> for SendStream<S, B>
 where
     S: quic::SendStream<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     type Error = S::Error;
 
@@ -129,7 +129,7 @@ where
         self.stream.send_id()
     }
 
-    async fn send_data<T: Into<h3::stream::WriteBuf<B>>>(&mut self, data: T) -> Result<(), Self::Error> {
+    async fn send_data<T: Into<h3::stream::WriteBuf<B>> + Send>(&mut self, data: T) -> Result<(), Self::Error> {
         self.stream.send_data(data).await
     }
 }
@@ -214,7 +214,7 @@ impl<S, B> BidiStream<S, B> {
 impl<S, B> quic::SendStream<B> for BidiStream<S, B>
 where
     S: quic::SendStream<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     type Error = S::Error;
 
@@ -230,7 +230,7 @@ where
         self.stream.send_id()
     }
 
-    async fn send_data<T: Into<h3::stream::WriteBuf<B>>>(
+    async fn send_data<T: Into<h3::stream::WriteBuf<B>> + Send>(
         &mut self,
         data: T,
     ) -> Result<(), Self::Error> {
@@ -241,7 +241,7 @@ where
 impl<S, B> quic::SendStreamUnframed<B> for BidiStream<S, B>
 where
     S: quic::SendStreamUnframed<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     fn poll_send<D: Buf>(
         &mut self,
@@ -276,7 +276,7 @@ impl<S: quic::RecvStream, B> quic::RecvStream for BidiStream<S, B> {
 impl<S, B> quic::BidiStream<B> for BidiStream<S, B>
 where
     S: quic::BidiStream<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     type SendStream = SendStream<S::SendStream, B>;
 

--- a/h3-webtransport/src/stream.rs
+++ b/h3-webtransport/src/stream.rs
@@ -129,12 +129,8 @@ where
         self.stream.send_id()
     }
 
-    fn send_data<T: Into<h3::stream::WriteBuf<B>>>(&mut self, data: T) -> Result<(), Self::Error> {
-        self.stream.send_data(data)
-    }
-
-    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.stream.poll_ready(cx)
+    async fn send_data<T: Into<h3::stream::WriteBuf<B>>>(&mut self, data: T) -> Result<(), Self::Error> {
+        self.stream.send_data(data).await
     }
 }
 
@@ -234,12 +230,11 @@ where
         self.stream.send_id()
     }
 
-    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.stream.poll_ready(cx)
-    }
-
-    fn send_data<T: Into<h3::stream::WriteBuf<B>>>(&mut self, data: T) -> Result<(), Self::Error> {
-        self.stream.send_data(data)
+    async fn send_data<T: Into<h3::stream::WriteBuf<B>>>(
+        &mut self,
+        data: T,
+    ) -> Result<(), Self::Error> {
+        self.stream.send_data(data).await
     }
 }
 

--- a/h3-webtransport/src/stream.rs
+++ b/h3-webtransport/src/stream.rs
@@ -98,7 +98,7 @@ impl<S, B> SendStream<S, B> {
 
 impl<S, B> quic::SendStreamUnframed<B> for SendStream<S, B>
 where
-    S: quic::SendStreamUnframed<B>,
+    S: quic::SendStreamUnframed<B> + quic::SendStream<B>,
     B: Buf + Send,
 {
     fn poll_send<D: Buf>(
@@ -129,7 +129,10 @@ where
         self.stream.send_id()
     }
 
-    async fn send_data<T: Into<h3::stream::WriteBuf<B>> + Send>(&mut self, data: T) -> Result<(), Self::Error> {
+    async fn send_data<T: Into<h3::stream::WriteBuf<B>> + Send>(
+        &mut self,
+        data: T,
+    ) -> Result<(), Self::Error> {
         self.stream.send_data(data).await
     }
 }
@@ -240,7 +243,7 @@ where
 
 impl<S, B> quic::SendStreamUnframed<B> for BidiStream<S, B>
 where
-    S: quic::SendStreamUnframed<B>,
+    S: quic::SendStreamUnframed<B> + quic::SendStream<B>,
     B: Buf + Send,
 {
     fn poll_send<D: Buf>(
@@ -275,7 +278,7 @@ impl<S: quic::RecvStream, B> quic::RecvStream for BidiStream<S, B> {
 
 impl<S, B> quic::BidiStream<B> for BidiStream<S, B>
 where
-    S: quic::BidiStream<B>,
+    S: quic::BidiStream<B> + quic::SendStream<B>,
     B: Buf + Send,
 {
     type SendStream = SendStream<S::SendStream, B>;

--- a/h3/Cargo.toml
+++ b/h3/Cargo.toml
@@ -28,8 +28,10 @@ futures-util = { version = "0.3", default-features = false, features = ["io"] }
 http = "1"
 tokio = { version = "1", features = ["sync"] }
 pin-project-lite = { version = "0.2", default_features = false }
+pin-project = "1.1.5"
 tracing = "0.1.40"
 fastrand = "2.0.1"
+trait-variant = "0.1.2"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/h3/src/client/builder.rs
+++ b/h3/src/client/builder.rs
@@ -49,7 +49,7 @@ where
 /// # where
 /// #   C: quic::Connection<B, OpenStreams = O>,
 /// #   O: quic::OpenStreams<B>,
-/// #   B: bytes::Buf,
+/// #   B: bytes::Buf + Send,
 /// # {
 /// let h3_conn = h3::client::builder()
 ///     .max_field_section_size(8192)
@@ -102,7 +102,7 @@ impl Builder {
     where
         C: quic::Connection<B, OpenStreams = O>,
         O: quic::OpenStreams<B>,
-        B: Buf,
+        B: Buf + Send,
     {
         let open = quic.opener();
         let conn_state = SharedStateRef::default();

--- a/h3/src/client/connection.rs
+++ b/h3/src/client/connection.rs
@@ -48,7 +48,7 @@ use super::stream::RequestStream;
 /// # async fn doc<T,B>(mut send_request: SendRequest<T, B>) -> Result<(), Box<dyn std::error::Error>>
 /// # where
 /// #     T: quic::OpenStreams<B>,
-/// #     B: Buf,
+/// #     B: Buf + Send,
 /// # {
 /// // Prepare the HTTP request to send to the server
 /// let request = Request::get("https://www.example.com/").body(())?;
@@ -118,7 +118,7 @@ where
 impl<T, B> SendRequest<T, B>
 where
     T: quic::OpenStreams<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     /// Send a HTTP/3 request to the server
     pub async fn send_request(
@@ -343,7 +343,7 @@ where
 impl<C, B> Connection<C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     /// Initiate a graceful shutdown, accepting `max_push` potentially in-flight server pushes
     pub async fn shutdown(&mut self, _max_push: usize) -> Result<(), Error> {

--- a/h3/src/client/stream.rs
+++ b/h3/src/client/stream.rs
@@ -167,7 +167,7 @@ where
 impl<S, B> RequestStream<S, B>
 where
     S: quic::SendStream<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     /// Send some data on the request body.
     pub async fn send_data(&mut self, buf: B) -> Result<(), Error> {
@@ -204,7 +204,7 @@ where
 impl<S, B> RequestStream<S, B>
 where
     S: quic::BidiStream<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     /// Split this stream into two halves that can be driven independently.
     pub fn split(

--- a/h3/src/client/stream.rs
+++ b/h3/src/client/stream.rs
@@ -166,7 +166,7 @@ where
 
 impl<S, B> RequestStream<S, B>
 where
-    S: quic::SendStream<B>,
+    S: quic::SendStreamLocal<B>,
     B: Buf + Send,
 {
     /// Send some data on the request body.

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -140,7 +140,7 @@ where
 impl<B, C> ConnectionInner<C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     pub async fn send_settings(&mut self) -> Result<(), Error> {
         #[cfg(test)]
@@ -753,7 +753,7 @@ where
 impl<S, B> RequestStream<S, B>
 where
     S: quic::SendStream<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     /// Send some data on the response body.
     pub async fn send_data(&mut self, buf: B) -> Result<(), Error> {
@@ -819,7 +819,7 @@ where
 impl<S, B> RequestStream<S, B>
 where
     S: quic::BidiStream<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     pub(crate) fn split(
         self,

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -21,7 +21,7 @@ use crate::{
         varint::VarInt,
     },
     qpack,
-    quic::{self, SendStream as _},
+    quic::{self, SendStreamLocal as _},
     stream::{self, AcceptRecvStream, AcceptedRecvStream, BufRecvStream, UniStreamHeader},
     webtransport::SessionId,
 };
@@ -752,7 +752,7 @@ where
 
 impl<S, B> RequestStream<S, B>
 where
-    S: quic::SendStream<B>,
+    S: quic::SendStreamLocal<B>,
     B: Buf + Send,
 {
     /// Send some data on the response body.

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -759,7 +759,8 @@ where
     pub async fn send_data(&mut self, buf: B) -> Result<(), Error> {
         let frame = Frame::Data(buf);
 
-        stream::write(&mut self.stream, frame)
+        self.stream
+            .send_data(frame)
             .await
             .map_err(|e| self.maybe_conn_err(e))?;
         Ok(())
@@ -788,7 +789,8 @@ where
         if mem_size > max_mem_size {
             return Err(Error::header_too_big(mem_size, max_mem_size));
         }
-        stream::write(&mut self.stream, Frame::Headers(block.freeze()))
+        self.stream
+            .send_data(Frame::Headers(block.freeze()))
             .await
             .map_err(|e| self.maybe_conn_err(e))?;
 
@@ -804,7 +806,8 @@ where
     pub async fn finish(&mut self) -> Result<(), Error> {
         if self.send_grease_frame {
             // send a grease frame once per Connection
-            stream::write(&mut self.stream, Frame::Grease)
+            self.stream
+                .send_data(Frame::Grease)
                 .await
                 .map_err(|e| self.maybe_conn_err(e))?;
             self.send_grease_frame = false;

--- a/h3/src/frame.rs
+++ b/h3/src/frame.rs
@@ -4,7 +4,7 @@ use bytes::Buf;
 
 use tracing::trace;
 
-use crate::quic::SendStream;
+use crate::quic::{SendStream, SendStreamLocal};
 use crate::stream::{BufRecvStream, WriteBuf};
 use crate::{
     buf::BufList,
@@ -150,10 +150,13 @@ where
 
 impl<T, B> FrameStream<T, B>
 where
-    T: SendStream<B> + Send,
-    B: Buf + Send,
+    T: SendStreamLocal<B>,
+    B: Buf,
 {
-    pub async fn send_data<D: Into<WriteBuf<B>> + Send>(&mut self, data: D) -> Result<(), T::Error> {
+    pub async fn send_data<D: Into<WriteBuf<B>> + Send>(
+        &mut self,
+        data: D,
+    ) -> Result<(), T::Error> {
         self.stream.send_data(data).await
     }
 

--- a/h3/src/frame.rs
+++ b/h3/src/frame.rs
@@ -154,12 +154,8 @@ where
 {
     type Error = <T as SendStream<B>>::Error;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.stream.poll_ready(cx)
-    }
-
-    fn send_data<D: Into<WriteBuf<B>>>(&mut self, data: D) -> Result<(), Self::Error> {
-        self.stream.send_data(data)
+    async fn send_data<D: Into<WriteBuf<B>>>(&mut self, data: D) -> Result<(), Self::Error> {
+        self.stream.send_data(data).await
     }
 
     fn poll_finish(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/h3/src/frame.rs
+++ b/h3/src/frame.rs
@@ -148,26 +148,24 @@ where
     }
 }
 
-impl<T, B> SendStream<B> for FrameStream<T, B>
+impl<T, B> FrameStream<T, B>
 where
     T: SendStream<B> + Send,
     B: Buf + Send,
 {
-    type Error = <T as SendStream<B>>::Error;
-
-    async fn send_data<D: Into<WriteBuf<B>> + Send>(&mut self, data: D) -> Result<(), Self::Error> {
+    pub async fn send_data<D: Into<WriteBuf<B>> + Send>(&mut self, data: D) -> Result<(), T::Error> {
         self.stream.send_data(data).await
     }
 
-    fn poll_finish(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    pub fn poll_finish(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), T::Error>> {
         self.stream.poll_finish(cx)
     }
 
-    fn reset(&mut self, reset_code: u64) {
+    pub fn reset(&mut self, reset_code: u64) {
         self.stream.reset(reset_code)
     }
 
-    fn send_id(&self) -> StreamId {
+    pub fn send_id(&self) -> StreamId {
         self.stream.send_id()
     }
 }

--- a/h3/src/quic.rs
+++ b/h3/src/quic.rs
@@ -139,7 +139,8 @@ pub trait OpenStreams<B: Buf> {
 }
 
 /// A trait describing the "send" actions of a QUIC stream.
-pub trait SendStream<B> {
+#[trait_variant::make(SendStream: Send)]
+pub trait SendStreamLocal<B> {
     /// The error type returned by fallible send methods.
     type Error: Into<Box<dyn Error>>;
 
@@ -150,10 +151,10 @@ pub trait SendStream<B> {
     //fn set_data<T: Into<WriteBuf<B>>>(&mut self, data: T) -> Result<(), Self::Error>;
 
     /// Sends data on the stream.
-    fn send_data<T: Into<WriteBuf<B>> + Send>(
+    async fn send_data<T: Into<WriteBuf<B>> + Send>(
         &mut self,
         data: T,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Self::Error>;
 
     /// Poll to finish the sending side of the stream.
     fn poll_finish(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>>;

--- a/h3/src/server/builder.rs
+++ b/h3/src/server/builder.rs
@@ -9,7 +9,7 @@
 //! fn doc<C,B>(conn: C)
 //! where
 //! C: h3::quic::Connection<B>,
-//! B: bytes::Buf,
+//! B: bytes::Buf + Send,
 //! {
 //!     let mut server_builder = h3::server::builder();
 //!     // Set the maximum header size
@@ -123,7 +123,7 @@ impl Builder {
     pub async fn build<C, B>(&self, conn: C) -> Result<Connection<C, B>, Error>
     where
         C: quic::Connection<B>,
-        B: Buf,
+        B: Buf + Send,
     {
         let (sender, receiver) = mpsc::unbounded_channel();
         Ok(Connection {

--- a/h3/src/server/connection.rs
+++ b/h3/src/server/connection.rs
@@ -51,7 +51,7 @@ use super::stream::{ReadDatagram, RequestStream};
 pub struct Connection<C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     /// TODO: temporarily break encapsulation for `WebTransportSession`
     pub inner: ConnectionInner<C, B>,
@@ -72,7 +72,7 @@ where
 impl<C, B> ConnectionState for Connection<C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     fn shared_state(&self) -> &SharedStateRef {
         &self.inner.shared
@@ -82,7 +82,7 @@ where
 impl<C, B> Connection<C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     /// Create a new HTTP/3 server connection with default settings
     ///
@@ -102,7 +102,7 @@ where
 impl<C, B> Connection<C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     /// Accept an incoming request.
     ///
@@ -417,7 +417,7 @@ where
 impl<C, B> Connection<C, B>
 where
     C: quic::Connection<B> + SendDatagramExt<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     /// Sends a datagram
     pub fn send_datagram(&mut self, stream_id: StreamId, data: B) -> Result<(), Error> {
@@ -433,7 +433,7 @@ where
 impl<C, B> Connection<C, B>
 where
     C: quic::Connection<B> + RecvDatagramExt,
-    B: Buf,
+    B: Buf + Send,
 {
     /// Reads an incoming datagram
     pub fn read_datagram(&mut self) -> ReadDatagram<C, B> {
@@ -447,7 +447,7 @@ where
 impl<C, B> Drop for Connection<C, B>
 where
     C: quic::Connection<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     fn drop(&mut self) {
         self.inner.close(Code::H3_NO_ERROR, "");

--- a/h3/src/server/connection.rs
+++ b/h3/src/server/connection.rs
@@ -31,7 +31,7 @@ use crate::{
         push::PushId,
     },
     qpack,
-    quic::{self, RecvDatagramExt, SendDatagramExt, SendStream as _},
+    quic::{self, RecvDatagramExt, SendDatagramExt, SendStreamLocal as _},
     stream::BufRecvStream,
 };
 

--- a/h3/src/server/mod.rs
+++ b/h3/src/server/mod.rs
@@ -2,14 +2,15 @@
 //!
 //! It allows to accept incoming requests, and send responses.
 //!
-//! # Examples
+//! # Examplesm
 //!
 //! ## Simple example
 //! ```rust
 //! async fn doc<C>(conn: C)
 //! where
 //! C: h3::quic::Connection<bytes::Bytes>,
-//! <C as h3::quic::Connection<bytes::Bytes>>::BidiStream: Send + 'static
+//! <C as h3::quic::Connection<bytes::Bytes>>::BidiStream: h3::quic::SendStream<bytes::Bytes> + Send + 'static,
+//! <C as h3::quic::Connection<bytes::Bytes>>::SendStream: h3::quic::SendStream<bytes::Bytes> + Send + 'static,
 //! {
 //!     let mut server_builder = h3::server::builder();
 //!     // Build the Connection

--- a/h3/src/server/request.rs
+++ b/h3/src/server/request.rs
@@ -14,7 +14,7 @@ pub struct ResolveRequest<C: quic::Connection<B>, B: Buf> {
     max_field_section_size: u64,
 }
 
-impl<B: Buf, C: quic::Connection<B>> ResolveRequest<C, B> {
+impl<B: Buf + Send, C: quic::Connection<B>> ResolveRequest<C, B> {
     pub fn new(
         request_stream: RequestStream<C::BidiStream, B>,
         decoded: Result<qpack::Decoded, u64>,

--- a/h3/src/server/stream.rs
+++ b/h3/src/server/stream.rs
@@ -124,7 +124,9 @@ where
             return Err(Error::header_too_big(mem_size, max_mem_size));
         }
 
-        stream::write(&mut self.inner.stream, Frame::Headers(block.freeze()))
+        self.inner
+            .stream
+            .send_data(Frame::Headers(block.freeze()))
             .await
             .map_err(|e| self.maybe_conn_err(e))?;
 

--- a/h3/src/server/stream.rs
+++ b/h3/src/server/stream.rs
@@ -91,7 +91,7 @@ where
 
 impl<S, B> RequestStream<S, B>
 where
-    S: quic::SendStream<B>,
+    S: quic::SendStreamLocal<B>,
     B: Buf + Send,
 {
     /// Send the HTTP/3 response

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -19,7 +19,7 @@ use crate::{
         stream::StreamType,
         varint::VarInt,
     },
-    quic::{self, BidiStream, RecvStream, SendStream, SendStreamUnframed},
+    quic::{self, BidiStream, RecvStream, SendStream, SendStreamLocal, SendStreamUnframed},
     webtransport::SessionId,
     Error,
 };
@@ -28,7 +28,7 @@ use crate::{
 /// Transmits data by encoding in wire format.
 pub(crate) async fn write<S, D, B>(stream: &mut S, data: D) -> Result<(), Error>
 where
-    S: SendStream<B>,
+    S: SendStreamLocal<B>,
     D: Into<WriteBuf<B>> + Send,
     B: Buf,
 {
@@ -493,8 +493,8 @@ impl<S: RecvStream, B> RecvStream for BufRecvStream<S, B> {
 
 impl<S, B> BufRecvStream<S, B>
 where
-    B: Buf + Send,
-    S: SendStream<B> + Send,
+    B: Buf,
+    S: SendStreamLocal<B>,
 {
     pub fn poll_finish(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), S::Error>> {
         self.stream.poll_finish(cx)
@@ -518,8 +518,8 @@ where
 
 impl<S, B> BufRecvStream<S, B>
 where
-    B: Buf + Send,
-    S: SendStreamUnframed<B> + Send,
+    B: Buf,
+    S: SendStreamUnframed<B>,
 {
     #[inline]
     pub fn poll_send<D: Buf>(
@@ -534,7 +534,7 @@ where
 impl<S, B> BufRecvStream<S, B>
 where
     B: Buf + Send,
-    S: BidiStream<B> + Send,
+    S: BidiStream<B>,
 {
     pub fn split(
         self,

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -493,8 +493,8 @@ impl<S: RecvStream, B> RecvStream for BufRecvStream<S, B> {
 
 impl<S, B> SendStream<B> for BufRecvStream<S, B>
 where
-    B: Buf,
-    S: SendStream<B>,
+    B: Buf + Send,
+    S: SendStream<B> + Send,
 {
     type Error = S::Error;
 
@@ -510,18 +510,15 @@ where
         self.stream.send_id()
     }
 
-    fn send_data<T: Into<WriteBuf<B>> + Send>(
-        &mut self,
-        data: T,
-    ) -> impl std::future::Future<Output = Result<(), Self::Error>> {
-        async { self.stream.send_data(data).await }
+    async fn send_data<T: Into<WriteBuf<B>> + Send>(&mut self, data: T) -> Result<(), Self::Error> {
+        self.stream.send_data(data).await
     }
 }
 
 impl<S, B> SendStreamUnframed<B> for BufRecvStream<S, B>
 where
-    B: Buf,
-    S: SendStreamUnframed<B>,
+    B: Buf + Send,
+    S: SendStreamUnframed<B> + Send,
 {
     #[inline]
     fn poll_send<D: Buf>(
@@ -535,8 +532,8 @@ where
 
 impl<S, B> BidiStream<B> for BufRecvStream<S, B>
 where
-    B: Buf,
-    S: BidiStream<B>,
+    B: Buf + Send,
+    S: BidiStream<B> + Send,
 {
     type SendStream = BufRecvStream<S::SendStream, B>;
 
@@ -635,7 +632,7 @@ where
 
 impl<S, B> futures_util::io::AsyncWrite for BufRecvStream<S, B>
 where
-    B: Buf,
+    B: Buf + Send,
     S: SendStreamUnframed<B>,
     S::Error: Into<std::io::Error>,
 {
@@ -660,7 +657,7 @@ where
 
 impl<S, B> tokio::io::AsyncWrite for BufRecvStream<S, B>
 where
-    B: Buf,
+    B: Buf + Send,
     S: SendStreamUnframed<B>,
     S::Error: Into<std::io::Error>,
 {

--- a/h3/src/tests/connection.rs
+++ b/h3/src/tests/connection.rs
@@ -9,6 +9,7 @@ use futures_util::future;
 use http::{Request, Response, StatusCode};
 
 use crate::client::SendRequest;
+use crate::quic::SendStream;
 use crate::{client, server};
 use crate::{
     connection::ConnectionState,
@@ -20,7 +21,7 @@ use crate::{
         stream::StreamType,
         varint::VarInt,
     },
-    quic::{self, SendStream},
+    quic::{self, SendStreamLocal},
 };
 
 use super::h3_quinn;
@@ -728,7 +729,7 @@ async fn request<T, O, B>(mut send_request: T) -> Result<Response<()>, Error>
 where
     T: BorrowMut<SendRequest<O, B>>,
     O: quic::OpenStreams<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     let mut request_stream = send_request
         .borrow_mut()
@@ -740,7 +741,7 @@ where
 async fn response<S, B>(mut stream: server::RequestStream<S, B>)
 where
     S: quic::RecvStream + SendStream<B>,
-    B: Buf,
+    B: Buf + Send,
 {
     stream
         .send_response(

--- a/h3/src/tests/connection.rs
+++ b/h3/src/tests/connection.rs
@@ -740,7 +740,7 @@ where
 
 async fn response<S, B>(mut stream: server::RequestStream<S, B>)
 where
-    S: quic::RecvStream + SendStream<B>,
+    S: quic::RecvStream + SendStreamLocal<B>,
     B: Buf + Send,
 {
     stream


### PR DESCRIPTION
at the moment there are two trait functions to send data. 
- `send_data` to prepare data for sending
- `poll_ready` to poll the stream until the data is sent

This PR uses the async fn in traits feature to introduce the `async fn send_data` function in the `SendStream` trait.

Advantages:  
- Simplifying the `h3_quinn` crate
   -  Removes error paths. `h3_quinn` panics if some functions are called while the boxed future is not ready. Users of `h3_quinn`+ `h3` might be able to get this, for example when using `RequestStream` in a Mutex. (but I'm not sure)
   - Avoids boxing the future
   - Avoids cloning the data before sending
- In h3 it is no longer possible to accidentally call `send_data` without `poll_ready`

Disadvantages
- Breaks MSRV
- Send bounds? (maybe they can be removed).
- idk maybe more?

Open:

- [ ] Try to remove Send bounds
- [ ] Fix WebTransport
- [ ] Fix missing Tests
- [ ] Documentation

Is it worth exploring this approach? 