### PR TITLE
Add WebSocket :protocol extension per RFC 9220.

### DIFF
--- a/h3/src/ext.rs
+++ b/h3/src/ext.rs
@@ -22,6 +22,8 @@ impl Protocol {
     pub const WEB_TRANSPORT: Protocol = Protocol(ProtocolInner::WebTransport);
     /// RFC 9298 protocol
     pub const CONNECT_UDP: Protocol = Protocol(ProtocolInner::ConnectUdp);
+    /// RFC 9220 (WebSocket) protocol
+    pub const WEBSOCKET: Protocol = Protocol(ProtocolInner::WebSocket);
 
     /// Return a &str representation of the `:protocol` pseudo-header value
     #[inline]
@@ -29,6 +31,7 @@ impl Protocol {
         match self.0 {
             ProtocolInner::WebTransport => "webtransport",
             ProtocolInner::ConnectUdp => "connect-udp",
+            ProtocolInner::WebSocket => "websocket",
         }
     }
 }
@@ -37,6 +40,7 @@ impl Protocol {
 enum ProtocolInner {
     WebTransport,
     ConnectUdp,
+    WebSocket,
 }
 
 /// Error when parsing the protocol
@@ -49,6 +53,7 @@ impl FromStr for Protocol {
         match s {
             "webtransport" => Ok(Self(ProtocolInner::WebTransport)),
             "connect-udp" => Ok(Self(ProtocolInner::ConnectUdp)),
+            "websocket" => Ok(Self(ProtocolInner::WebSocket)),
             _ => Err(InvalidProtocol),
         }
     }


### PR DESCRIPTION
Attempt to add WebSocket support to h3.

I don't know any server that supports RFC 9220, so it is untested.