### PR TITLE
make h3 able to connect to nginx

### DIFF
--- a/h3/Cargo.toml
+++ b/h3/Cargo.toml
@@ -26,7 +26,7 @@ i-implement-a-third-party-backend-and-opt-into-breaking-changes = []
 bytes = "1"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 http = "1"
-tokio = { version = "1", features = ["sync", "macros"] }
+tokio = { version = "1", features = ["sync"] }
 pin-project-lite = { version = "0.2", default_features = false }
 tracing = "0.1.40"
 fastrand = "2.0.1"

--- a/h3/Cargo.toml
+++ b/h3/Cargo.toml
@@ -26,7 +26,7 @@ i-implement-a-third-party-backend-and-opt-into-breaking-changes = []
 bytes = "1"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 http = "1"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "macros"] }
 pin-project-lite = { version = "0.2", default_features = false }
 tracing = "0.1.40"
 fastrand = "2.0.1"

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -207,7 +207,7 @@ where
         let mut decoder_send = Option::take(&mut self.decoder_send);
         let mut encoder_send = Option::take(&mut self.encoder_send);
 
-        let (control, ..) = tokio::join!(
+        let (control, ..) = future::join3(
             stream::write(
                 &mut self.control_send,
                 WriteBuf::from(UniStreamHeader::Control(settings)),
@@ -221,8 +221,9 @@ where
                 if let Some(stream) = &mut encoder_send {
                     let _ = stream::write(stream, WriteBuf::from(UniStreamHeader::Encoder)).await;
                 }
-            }
-        );
+            },
+        )
+        .await;
 
         self.decoder_send = decoder_send;
         self.encoder_send = encoder_send;

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -237,7 +237,7 @@ where
         //# unidirectional streams required by mandatory extensions (such as the
         //# QPACK encoder and decoder streams) first, and then create additional
 
-        // start streams concurrently
+        // start streams
         let (control_send, qpack_encoder, qpack_decoder) = (
             future::poll_fn(|cx| conn.poll_open_send(cx)).await,
             future::poll_fn(|cx| conn.poll_open_send(cx)).await,
@@ -670,6 +670,7 @@ where
             self.grease_step = GreaseStatus::Finished;
         };
 
+        warn!("grease stream finished");
         // grease stream is closed
         // dont do another one
         self.send_grease_stream_flag = false;

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -655,6 +655,10 @@ where
             });
         };
 
+        //= https://www.rfc-editor.org/rfc/rfc9114#section-6.2.3
+        //# When sending a reserved stream type,
+        //# the implementation MAY either terminate the stream cleanly or reset
+        //# it.
         if let GreaseStatus::DataSent(stream) = &mut self.grease_step {
             match stream.poll_finish(cx) {
                 Poll::Ready(Ok(_)) => (),
@@ -670,7 +674,6 @@ where
             self.grease_step = GreaseStatus::Finished;
         };
 
-        warn!("grease stream finished");
         // grease stream is closed
         // dont do another one
         self.send_grease_stream_flag = false;

--- a/h3/src/proto/frame.rs
+++ b/h3/src/proto/frame.rs
@@ -536,7 +536,7 @@ impl Settings {
                 //# H3_SETTINGS_ERROR.
                 settings.insert(identifier, value)?;
             } else {
-                tracing::warn!("Unsupported setting: {:#x?}", identifier);
+                tracing::debug!("Unsupported setting: {:#x?}", identifier);
             }
         }
         Ok(settings)

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -119,6 +119,8 @@ where
 pub enum UniStreamHeader {
     Control(Settings),
     WebTransportUni(SessionId),
+    Encoder,
+    Decoder,
 }
 
 impl Encode for UniStreamHeader {
@@ -131,6 +133,12 @@ impl Encode for UniStreamHeader {
             Self::WebTransportUni(session_id) => {
                 StreamType::WEBTRANSPORT_UNI.encode(buf);
                 session_id.encode(buf);
+            }
+            UniStreamHeader::Encoder => {
+                StreamType::ENCODER.encode(buf);
+            }
+            UniStreamHeader::Decoder => {
+                StreamType::DECODER.encode(buf);
             }
         }
     }

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -154,17 +154,12 @@ where
 }
 
 pub enum BidiStreamHeader {
-    Control(Settings),
     WebTransportBidi(SessionId),
 }
 
 impl Encode for BidiStreamHeader {
     fn encode<B: BufMut>(&self, buf: &mut B) {
         match self {
-            Self::Control(settings) => {
-                StreamType::CONTROL.encode(buf);
-                settings.encode(buf);
-            }
             Self::WebTransportBidi(session_id) => {
                 StreamType::WEBTRANSPORT_BIDI.encode(buf);
                 session_id.encode(buf);


### PR DESCRIPTION
This starts the qpack streams, but does not use them.
Nginx ends the Connection with a Connection error when receiving h3s grease stream when they are not present.

The creation of `ConnectionInner` does now not wait for the grease stream to finnish. The grease stream is now handled in the background in the `poll_control`.