### PR TITLE
Added .id() for client RequestStream

### DIFF
--- a/h3/src/client/stream.rs
+++ b/h3/src/client/stream.rs
@@ -1,6 +1,7 @@
 use bytes::Buf;
 use futures_util::future;
 use http::{HeaderMap, Response};
+use quic::StreamId;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
@@ -167,6 +168,11 @@ where
         // TODO take by value to prevent any further call as this request is cancelled
         // rename `cancel()` ?
         self.inner.stream.stop_sending(error_code)
+    }
+
+    /// Returns the underlying stream id
+    pub fn id(&self) -> StreamId {
+        self.inner.stream.id()
     }
 }
 


### PR DESCRIPTION
Currently only server RequestStream has ability to get StreamId. However would also be a very useful capability on the client side - especially for synchronisation of streams with datagrams.