### PR TITLE
Expose poll_recv_trailers APIs

### DIFF
--- a/h3/src/client/stream.rs
+++ b/h3/src/client/stream.rs
@@ -173,7 +173,7 @@ where
         res
     }
 
-    /// Receive an optional set of trailers for the response.
+    /// Poll receive an optional set of trailers for the response.
     pub fn poll_recv_trailers(
         &mut self,
         cx: &mut Context<'_>,

--- a/h3/src/client/stream.rs
+++ b/h3/src/client/stream.rs
@@ -164,16 +164,11 @@ where
     /// Receive an optional set of trailers for the response.
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     pub async fn recv_trailers(&mut self) -> Result<Option<HeaderMap>, Error> {
-        let res = self.inner.recv_trailers().await;
-        if let Err(ref e) = res {
-            if e.is_header_too_big() {
-                self.inner.stream.stop_sending(Code::H3_REQUEST_CANCELLED);
-            }
-        }
-        res
+        future::poll_fn(|cx| self.poll_recv_trailers(cx)).await
     }
 
     /// Poll receive an optional set of trailers for the response.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     pub fn poll_recv_trailers(
         &mut self,
         cx: &mut Context<'_>,

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -792,8 +792,8 @@ where
         future::poll_fn(|cx| self.poll_recv_data(cx)).await
     }
 
-    // matching h2 impl https://github.com/hyperium/h2/blob/3bce93e9b0dad742ffbf62d25f9607ef7651a70c/src/share.rs#L427
-
+    /// Poll receive trailers.
+    #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     pub fn poll_recv_trailers(
         &mut self,
         cx: &mut Context<'_>,

--- a/h3/src/server/stream.rs
+++ b/h3/src/server/stream.rs
@@ -84,7 +84,8 @@ where
         self.inner.recv_trailers().await
     }
 
-    /// Poll for trailers sent from client
+    /// Poll for an optional set of trailers for the request
+    #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     pub fn poll_recv_trailers(
         &mut self,
         cx: &mut Context<'_>,

--- a/h3/src/server/stream.rs
+++ b/h3/src/server/stream.rs
@@ -84,6 +84,14 @@ where
         self.inner.recv_trailers().await
     }
 
+    /// Poll for trailers sent from client
+    pub fn poll_recv_trailers(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Error>> {
+        self.inner.poll_recv_trailers(cx)
+    }
+
     /// Tell the peer to stop sending into the underlying QUIC stream
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     pub fn stop_sending(&mut self, error_code: crate::error::Code) {

--- a/h3/src/server/stream.rs
+++ b/h3/src/server/stream.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use bytes::BytesMut;
-use futures_util::{future::Future, ready};
+use futures_util::{future, future::Future, ready};
 use http::{response, HeaderMap, Response};
 
 use quic::StreamId;
@@ -81,7 +81,7 @@ where
     /// Receive an optional set of trailers for the request
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     pub async fn recv_trailers(&mut self) -> Result<Option<HeaderMap>, Error> {
-        self.inner.recv_trailers().await
+        future::poll_fn(|cx| self.poll_recv_trailers(cx)).await
     }
 
     /// Poll for an optional set of trailers for the request


### PR DESCRIPTION
Expose poll style APIs for receive trailers (and data).
I need these APIs to imbed the h3 connection into http body and implement the poll_frame. With this change I can successfully send and receive http::Request body with streaming.

This also matches the h2 poll_trailers api:
https://github.com/hyperium/h2/blob/3bce93e9b0dad742ffbf62d25f9607ef7651a70c/src/share.rs#L427