### PR TITLE
Client also needs an ability to stop streams with error code

### DIFF
--- a/h3/src/client/stream.rs
+++ b/h3/src/client/stream.rs
@@ -207,6 +207,13 @@ where
         self.inner.send_data(buf).await
     }
 
+    /// Stop a stream with an error code
+    ///
+    /// The code can be [`Code::H3_NO_ERROR`].
+    pub fn stop_stream(&mut self, error_code: Code) {
+        self.inner.stop_stream(error_code);
+    }
+
     /// Send a set of trailers to end the request.
     ///
     /// [`RequestStream::finish()`] must be called to finalize a request.


### PR DESCRIPTION
For some reason stop_stream is currently only available for server streams.

However, it is also useful for clients to be able to stop streams with an error code - for example on disconnect of CONNECT socket or to close stream on receiving malformed capsule when using capsule protocol inside h3 stream.