### PR TITLE
Add datagram support for client

### DIFF
--- a/h3-datagram/src/client.rs
+++ b/h3-datagram/src/client.rs
@@ -1,11 +1,11 @@
-//! server API
+//! client API
 
 use std::marker::PhantomData;
 
 use bytes::Buf;
 use h3::{
+    client::Connection,
     quic::{self, StreamId},
-    server::Connection,
     Error,
 };
 

--- a/h3-datagram/src/datagram_traits.rs
+++ b/h3-datagram/src/datagram_traits.rs
@@ -1,13 +1,23 @@
 //! Traits which define the user API for datagrams.
 //! These traits are implemented for the client and server types in the `h3` crate.
 
+use std::{
+    future::Future,
+    marker::PhantomData,
+    task::{ready, Context, Poll},
+};
+
 use bytes::Buf;
 use h3::{
     quic::{self, StreamId},
     Error,
 };
+use pin_project_lite::pin_project;
 
-use crate::server::ReadDatagram;
+use crate::{
+    datagram::Datagram,
+    quic_traits::{self, RecvDatagramExt},
+};
 
 pub trait HandleDatagramsExt<C, B>
 where
@@ -18,4 +28,32 @@ where
     fn send_datagram(&mut self, stream_id: StreamId, data: B) -> Result<(), Error>;
     /// Reads an incoming datagram
     fn read_datagram(&mut self) -> ReadDatagram<C, B>;
+}
+
+pin_project! {
+    /// Future for [`Connection::read_datagram`]
+    pub struct ReadDatagram<'a, C, B>
+    where
+            C: quic::Connection<B>,
+            B: Buf,
+        {
+            pub(crate) conn: &'a mut C,
+            pub(crate) _marker: PhantomData<B>,
+        }
+}
+
+impl<'a, C, B> Future for ReadDatagram<'a, C, B>
+where
+    C: quic::Connection<B> + RecvDatagramExt,
+    <C as quic_traits::RecvDatagramExt>::Error: h3::quic::Error + 'static,
+    B: Buf,
+{
+    type Output = Result<Option<Datagram<C::Buf>>, Error>;
+
+    fn poll(mut self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match ready!(self.conn.poll_accept_datagram(cx))? {
+            Some(v) => Poll::Ready(Ok(Some(Datagram::decode(v)?))),
+            None => Poll::Ready(Ok(None)),
+        }
+    }
 }

--- a/h3-datagram/src/lib.rs
+++ b/h3-datagram/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod datagram;
 pub mod datagram_traits;
 pub mod quic_traits;

--- a/h3/src/client/builder.rs
+++ b/h3/src/client/builder.rs
@@ -96,6 +96,14 @@ impl Builder {
         self
     }
 
+    /// Indicates that the client supports HTTP/3 datagrams
+    ///
+    /// See: <https://www.rfc-editor.org/rfc/rfc9297#section-2.1.1>
+    pub fn enable_datagram(&mut self, enabled: bool) -> &mut Self {
+        self.config.settings.enable_datagram = enabled;
+        self
+    }
+
     /// Create a new HTTP/3 client from a `quic` connection
     pub async fn build<C, O, B>(
         &mut self,

--- a/h3/src/client/connection.rs
+++ b/h3/src/client/connection.rs
@@ -336,7 +336,8 @@ where
     C: quic::Connection<B>,
     B: Buf,
 {
-    pub(super) inner: ConnectionInner<C, B>,
+    /// TODO: breaking encapsulation for RFC9298.
+    pub inner: ConnectionInner<C, B>,
     // Has a GOAWAY frame been sent? If so, this PushId is the last we are willing to accept.
     pub(super) sent_closing: Option<PushId>,
     // Has a GOAWAY frame been received? If so, this is StreamId the last the remote will accept.


### PR DESCRIPTION
As per #253 , these changes add the ability for a client to send HTTP datagrams over the underlying QUIC connection. I am not entirely sure about how the underlying QUIC connection is being exposed - I am open to better alternatives :) 