### PR TITLE
Add extended CONNECT setting for client conn

### DIFF
--- a/examples/webtransport_server.rs
+++ b/examples/webtransport_server.rs
@@ -118,7 +118,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     info!("new http3 established");
                     let h3_conn = h3::server::builder()
                         .enable_webtransport(true)
-                        .enable_connect(true)
+                        .enable_extended_connect(true)
                         .enable_datagram(true)
                         .max_webtransport_sessions(1)
                         .send_grease(true)

--- a/h3/src/client/builder.rs
+++ b/h3/src/client/builder.rs
@@ -104,6 +104,12 @@ impl Builder {
         self
     }
 
+    /// Enables the extended CONNECT protocol required for various HTTP/3 extensions.
+    pub fn enable_connect(&mut self, value: bool) -> &mut Self {
+        self.config.settings.enable_extended_connect = value;
+        self
+    }
+
     /// Create a new HTTP/3 client from a `quic` connection
     pub async fn build<C, O, B>(
         &mut self,

--- a/h3/src/client/builder.rs
+++ b/h3/src/client/builder.rs
@@ -105,7 +105,7 @@ impl Builder {
     }
 
     /// Enables the extended CONNECT protocol required for various HTTP/3 extensions.
-    pub fn enable_connect(&mut self, value: bool) -> &mut Self {
+    pub fn enable_extended_connect(&mut self, value: bool) -> &mut Self {
         self.config.settings.enable_extended_connect = value;
         self
     }

--- a/h3/src/server/builder.rs
+++ b/h3/src/server/builder.rs
@@ -89,7 +89,7 @@ impl Builder {
     ///
     ///
     /// **Server**:
-    /// Supporting for webtransport also requires setting `enable_connect` `enable_datagram`
+    /// Supporting for webtransport also requires setting `enable_extended_connect` `enable_datagram`
     /// and `max_webtransport_sessions`.
     #[inline]
     pub fn enable_webtransport(&mut self, value: bool) -> &mut Self {
@@ -97,8 +97,8 @@ impl Builder {
         self
     }
 
-    /// Enables the CONNECT protocol
-    pub fn enable_connect(&mut self, value: bool) -> &mut Self {
+    /// Enables the extended CONNECT protocol required for various HTTP/3 extensions.
+    pub fn enable_extended_connect(&mut self, value: bool) -> &mut Self {
         self.config.settings.enable_extended_connect = value;
         self
     }


### PR DESCRIPTION
Various HTTP/3 extensions that use HTTP datagrams such as [connect-udp](https://datatracker.ietf.org/doc/html/rfc9298), [connect-ip](https://www.rfc-editor.org/rfc/rfc9484.html), or [webtransport](https://datatracker.ietf.org/doc/draft-ietf-webtrans-overview/) rely on extended CONNECT. #280 added datagram support for client connections, however, to use it for any of the aforementioned protocols, we also need to be able to signal extended CONNECT support in the H3_SETTINGS.