### PR TITLE
h3-webtransport v0.1.1

### DIFF
--- a/changelog-h3-webtransport.md
+++ b/changelog-h3-webtransport.md
@@ -1,0 +1,3 @@
+# v0.1.1
+* update dependencies 
+* move datagram logic to its own crate

--- a/h3-webtransport/Cargo.toml
+++ b/h3-webtransport/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "h3-webtransport"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
+documentation = "https://docs.rs/h3-webtransport"
+repository = "https://github.com/hyperium/h3"
+readme = "readme.md"
+description = "webtransport extension for h3"
+keywords = ["http3", "quic", "webtransport"]
+categories = ["network-programming", "web-programming"]
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -12,7 +19,7 @@ http = "1"
 pin-project-lite = { version = "0.2", default-features = false }
 tracing = "0.1.37"
 tokio = { version = "1.28", default-features = false }
-h3-datagram = { path = "../h3-datagram" }
+h3-datagram = { version = "0.0.1", path = "../h3-datagram" }
 
 [dependencies.h3]
 version = "0.0.7"

--- a/h3-webtransport/readme.md
+++ b/h3-webtransport/readme.md
@@ -1,0 +1,6 @@
+# H3 Webtransport
+
+Implementation of Webtransport protocol as extension of the h3 crate
+
+# Status
+This crate is still in experimental. The API is subject to change. It may contain bugs and is not yet complete. Use with caution.


### PR DESCRIPTION
[h3-webtransport](https://crates.io/crates/h3-webtransport) is already published with v0.1 so this is 0.1.1. 