### PR TITLE
h3-quinn: fix usage of a private StreamId field

### DIFF
--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 [dependencies]
 h3 = { version = "0.0.7", path = "../h3" }
 bytes = "1"
-quinn = { version = "0.11", default-features = false, features = [
+quinn = { version = "0.11.7", default-features = false, features = [
     "futures-io",
 ] }
 tokio-util = { version = "0.7.9" }

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -499,13 +499,9 @@ impl quic::RecvStream for RecvStream {
 
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     fn recv_id(&self) -> StreamId {
-        self.stream
-            .as_ref()
-            .unwrap()
-            .id()
-            .0
-            .try_into()
-            .expect("invalid stream id")
+        let num: u64 = self.stream.as_ref().unwrap().id().into();
+
+        num.try_into().expect("invalid stream id")
     }
 }
 
@@ -628,7 +624,8 @@ where
 
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     fn send_id(&self) -> StreamId {
-        self.stream.id().0.try_into().expect("invalid stream id")
+        let num: u64 = self.stream.id().into();
+        num.try_into().expect("invalid stream id")
     }
 }
 

--- a/h3/src/stream.rs
+++ b/h3/src/stream.rs
@@ -688,7 +688,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use quinn_proto::coding::BufExt;
+    use crate::proto::coding::BufExt;
 
     use super::*;
 


### PR DESCRIPTION
We were accessing a field that was `doc(hidden)`. A new version of quinn-proto made this field actually private, but made it possible to convert a stream ID into a `u64`.