### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "cargo"
+    directories:
+      - "/"
+      - "/examples"
+      - "/fuzz"
+      - "/h3"
+      - "/h3-datagram"
+      - "/h3-quinn"
+      - "/h3-webtransport"
+    schedule:
+      interval: "weekly"

--- a/ci/h3spec.sh
+++ b/ci/h3spec.sh
@@ -3,7 +3,7 @@
 LOGFILE=h3server.log
 if ! [ -e "h3spec-linux-x86_64" ] ; then
     # if we don't already have a h3spec executable, wget it from github
-    wget https://github.com/kazu-yamamoto/h3spec/releases/download/v0.1.12/h3spec-linux-x86_64
+    wget https://github.com/kazu-yamamoto/h3spec/releases/download/v0.1.13/h3spec-linux-x86_64
     chmod +x h3spec-linux-x86_64
 fi
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -38,7 +38,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 octets = "0.3.0"
 
-tracing-tree = { version = "0.3" }
+tracing-tree = { version = "0.4" }
 h3-datagram = { path = "../h3-datagram" }
 
 [features]


### PR DESCRIPTION
### Updates
- CI h3spec 0.1.12 to 0.1.13
- examples tracing-tree 0.3 to 0.4
- Let Dependabot update cargo dependencies and GitHub Actions (to let CI catch breaking changes for example)

### Not changed
- [rustls-native-certs 0.8](https://github.com/rustls/rustls-native-certs/releases) contained breaking changes
- Some dependencies other than tokio updated to MSRV 1.71
- fuzz and h3 contain no README
- launch_chrome.sh could launch [Chromium](https://formulae.brew.sh/cask/chromium) as an alternative
- Some dependency constrains like bytes, fastrand and tokio are 2 years "old", do they still make sense in 2025?

<details><summary>cargo upgrade</summary><pre>
    Checking virtual workspace's dependencies
    Checking examples's dependencies
name    old req compatible latest new req
====    ======= ========== ====== =======
tokio   1.27    1.44.2     1.44.2 1.44
tracing 0.1.37  0.1.41     0.1.41 0.1.41
    Checking h3's dependencies
name       old req compatible latest new req
====       ======= ========== ====== =======
tracing    0.1.40  0.1.41     0.1.41 0.1.41
fastrand   2.0.1   2.3.0      2.3.0  2.3.0
futures    0.3.28  0.3.31     0.3.31 0.3.31
tokio-util 0.7.9   0.7.15     0.7.15 0.7.15
    Checking h3-datagram's dependencies
name    old req compatible latest new req
====    ======= ========== ====== =======
bytes   1.4     1.10.1     1.10.1 1.10
tracing 0.1.40  0.1.41     0.1.41 0.1.41
    Checking h3-quinn's dependencies
name       old req compatible latest new req
====       ======= ========== ====== =======
tokio-util 0.7.9   0.7.15     0.7.15 0.7.15
futures    0.3.28  0.3.31     0.3.31 0.3.31
tracing    0.1.40  0.1.41     0.1.41 0.1.41
    Checking h3-webtransport's dependencies
name    old req compatible latest new req
====    ======= ========== ====== =======
tracing 0.1.37  0.1.41     0.1.41 0.1.41
tokio   1.28    1.44.2     1.44.2 1.44
</pre></details>
