### PR TITLE
Expose qpack module as unstable

### DIFF
--- a/h3/src/lib.rs
+++ b/h3/src/lib.rs
@@ -32,6 +32,9 @@ pub mod frame;
 #[allow(missing_docs)]
 pub mod proto;
 #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
+#[allow(dead_code, missing_docs)]
+pub mod qpack;
+#[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
 #[allow(missing_docs)]
 pub mod stream;
 #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
@@ -45,12 +48,13 @@ mod frame;
 #[cfg(not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))]
 mod proto;
 #[cfg(not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))]
+#[allow(dead_code)]
+mod qpack;
+#[cfg(not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))]
 mod stream;
 #[cfg(not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))]
 mod webtransport;
 
-#[allow(dead_code)]
-mod qpack;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]


### PR DESCRIPTION
This PR exposes `h3::qpack` via the `i-implement-a-third-party-backend-and-opt-into-breaking-changes` feature.

Use case: I'm working on an HTTP/3 testing tool that requires low-level access to QUIC streams. h3's FrameStream is already super helpful for this, but currently there is no good way to decode header frames.

Perfectly understand if that's not a supported use case and you'd rather have me keep my fork, please feel free to just close this then. The only other qpack implementations I could find are ls-qpack (not pure Rust) and quiche::h3 (pulls in a million dependencies), so  I figured this could be useful to others, too. :)

Thank you for your work on h3! 🍰 