### PR TITLE
feat(h3-quinn): update quinn to 0.11.9

### DIFF
--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 [dependencies]
 h3 = { version = "0.0.8", path = "../h3" }
 bytes = "1"
-quinn = { version = "0.11.7", default-features = false, features = [
+quinn = { version = "0.11.9", default-features = false, features = [
     "futures-io",
 ] }
 tokio-util = { version = "0.7.9" }


### PR DESCRIPTION
I'd suggest to explicitly update `quinn` to `0.11.9` to use the new version of `socket2` (`0.6`), many other projects have already migrated to it and personally would want to do so to reduce duplicated dependencies.

Hope this is an appropiate request, thanks.