### PR TITLE
Correct behavior of standard CONNECT

### DIFF
--- a/h3/src/proto/headers.rs
+++ b/h3/src/proto/headers.rs
@@ -383,6 +383,14 @@ impl Pseudo {
             None
         };
 
+        // For standard CONNECT (that is, without :protocol pseudo-header) scheme and path
+        // are not set. See: [https://www.rfc-editor.org/rfc/rfc9114#section-4.4]
+        let (scheme, path) = if method == Method::CONNECT && protocol.is_none() {
+            (None, None)
+        } else {
+            (scheme.or(Some(Scheme::HTTPS)), Some(path))
+        };
+
         let len = 3 + authority.is_some() as usize + protocol.is_some() as usize;
 
         //= https://www.rfc-editor.org/rfc/rfc9114#section-4.3
@@ -398,9 +406,9 @@ impl Pseudo {
         //# CONNECT request; see Section 4.4.
         Self {
             method: Some(method),
-            scheme: scheme.or(Some(Scheme::HTTPS)),
+            scheme,
             authority,
-            path: Some(path),
+            path,
             status: None,
             protocol,
             len,


### PR DESCRIPTION
Currently h3 client always sets scheme (defaults to `https`) and path (defaults to `/`). This breaks compatibility with CONNECT servers that expect compliance with section 4.4 of RFC9114.

With this change scheme and path are not enforced for standard CONNECT (that is, CONNECT `:method` with no `:protocol` pseudo-header). FWIW, extended CONNECT (that is, CONNECT with some `:protocol`) requires scheme and path.