### PR TITLE
chore: trim unused dependencies, replace `futures` with `futures-util`

### DIFF
--- a/h3-datagram/Cargo.toml
+++ b/h3-datagram/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT"
 [dependencies]
 #h3 = { path = "../h3" }
 bytes = "1.4"
-pin-project-lite = { version = "0.2", default-features = false }
 tracing = { version = "0.1.40", optional = true }
 
 [features]

--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -19,8 +19,7 @@ quinn = { version = "0.11.7", default-features = false, features = [
     "futures-io",
 ] }
 tokio-util = { version = "0.7.9" }
-futures = { version = "0.3.28" }
-tokio = { version = "1", features = ["io-util"], default-features = false }
+futures-util = { version = "0.3.28", default-features = false }
 h3-datagram = {version = "0.0.2", path = "../h3-datagram", optional = true }
 tracing = { version = "0.1.40", optional = true }
 

--- a/h3-quinn/src/datagram.rs
+++ b/h3-quinn/src/datagram.rs
@@ -5,7 +5,7 @@
 use std::future::Future;
 use std::task::{ready, Poll};
 
-use futures::{stream, StreamExt};
+use futures_util::{stream, StreamExt};
 use h3_datagram::datagram::EncodedDatagram;
 use h3_datagram::quic_traits::{
     DatagramConnectionExt, RecvDatagram, SendDatagram, SendDatagramErrorIncoming,

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -8,13 +8,12 @@ use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
-    task::{self, Poll},
+    task::{self, ready, Poll},
 };
 
 use bytes::{Buf, Bytes};
 
-use futures::{
-    ready,
+use futures_util::{
     stream::{self},
     Stream, StreamExt,
 };


### PR DESCRIPTION
Minor tweaks to improve compile times.