### PR TITLE
WIP: Rework of internal receive buffering

### DIFF
--- a/h3-datagram/src/client.rs
+++ b/h3-datagram/src/client.rs
@@ -13,7 +13,7 @@ use crate::{
     quic_traits::DatagramConnectionExt,
 };
 
-impl<B, C> HandleDatagramsExt<C, B> for Connection<C, B>
+impl<C, B> HandleDatagramsExt<C, B> for Connection<C, B>
 where
     B: Buf,
     C: quic::Connection<B> + DatagramConnectionExt<B>,

--- a/h3-datagram/src/server.rs
+++ b/h3-datagram/src/server.rs
@@ -13,10 +13,10 @@ use crate::{
     quic_traits::DatagramConnectionExt,
 };
 
-impl<B, C> HandleDatagramsExt<C, B> for Connection<C, B>
+impl<C, B> HandleDatagramsExt<C, B> for Connection<C, B>
 where
-    B: Buf,
     C: quic::Connection<B> + DatagramConnectionExt<B>,
+    B: Buf,
 {
     /// Get the datagram sender
     fn get_datagram_sender(

--- a/h3/src/buf.rs
+++ b/h3/src/buf.rs
@@ -1,20 +1,22 @@
 use std::collections::VecDeque;
 use std::io::IoSlice;
 
-use bytes::{Buf, Bytes};
+use bytes::Buf;
 
 #[derive(Debug)]
 pub(crate) struct BufList<T> {
     bufs: VecDeque<T>,
 }
 
-impl<T: Buf> BufList<T> {
+impl<T> BufList<T> {
     pub(crate) fn new() -> BufList<T> {
         BufList {
             bufs: VecDeque::new(),
         }
     }
+}
 
+impl<T: Buf> BufList<T> {
     #[inline]
     #[allow(dead_code)]
     pub(crate) fn push(&mut self, buf: T) {
@@ -29,34 +31,6 @@ impl<T: Buf> BufList<T> {
             index: 0,
             pos_front: 0,
         }
-    }
-}
-
-impl BufList<Bytes> {
-    pub fn take_first_chunk(&mut self) -> Option<Bytes> {
-        self.bufs.pop_front()
-    }
-
-    pub fn take_chunk(&mut self, max_len: usize) -> Option<Bytes> {
-        let chunk = self
-            .bufs
-            .front_mut()
-            .map(|chunk| chunk.split_to(usize::min(max_len, chunk.remaining())));
-
-        if let Some(front) = self.bufs.front() {
-            if front.remaining() == 0 {
-                let _ = self.bufs.pop_front();
-            }
-        }
-        chunk
-    }
-
-    pub fn push_bytes<T>(&mut self, buf: &mut T)
-    where
-        T: Buf,
-    {
-        debug_assert!(buf.has_remaining());
-        self.bufs.push_back(buf.copy_to_bytes(buf.remaining()))
     }
 }
 

--- a/h3/src/client/builder.rs
+++ b/h3/src/client/builder.rs
@@ -28,7 +28,7 @@ pub async fn new<C, O>(
 ) -> Result<(Connection<C, Bytes>, SendRequest<O, Bytes>), ConnectionError>
 where
     C: quic::Connection<Bytes, OpenStreams = O>,
-    O: quic::OpenStreams<Bytes>,
+    O: quic::OpenStreams<Bytes, BidiStream: quic::RecvStream<Buf = Bytes>>,
 {
     //= https://www.rfc-editor.org/rfc/rfc9114#section-3.3
     //= type=implication

--- a/h3/src/server/builder.rs
+++ b/h3/src/server/builder.rs
@@ -27,6 +27,7 @@ use bytes::Buf;
 
 use tokio::sync::mpsc;
 
+use super::connection::Connection;
 use crate::{
     config::Config,
     connection::ConnectionInner,
@@ -34,8 +35,6 @@ use crate::{
     quic::{self},
     shared_state::SharedState,
 };
-
-use super::connection::Connection;
 
 /// Create a builder of HTTP/3 server connections
 ///

--- a/h3/src/server/connection.rs
+++ b/h3/src/server/connection.rs
@@ -96,7 +96,10 @@ where
 {
     #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
     /// Create a [`RequestResolver`] to handle an incoming request.
-    pub fn create_resolver(&self, stream: FrameStream<C::BidiStream, B>) -> RequestResolver<C, B> {
+    pub fn create_resolver(
+        &self,
+        stream: FrameStream<C::BidiStream, B, <C::BidiStream as RecvStream>::Buf>,
+    ) -> RequestResolver<C, B> {
         self.create_resolver_internal(stream)
     }
 
@@ -142,7 +145,7 @@ where
 
     fn create_resolver_internal(
         &self,
-        stream: FrameStream<C::BidiStream, B>,
+        stream: FrameStream<C::BidiStream, B, <C::BidiStream as RecvStream>::Buf>,
     ) -> RequestResolver<C, B> {
         RequestResolver {
             frame_stream: stream,

--- a/h3/src/server/mod.rs
+++ b/h3/src/server/mod.rs
@@ -9,7 +9,8 @@
 //! async fn doc<C>(conn: C)
 //! where
 //! C: h3::quic::Connection<bytes::Bytes> + 'static,
-//! <C as h3::quic::OpenStreams<bytes::Bytes>>::BidiStream: Send + 'static
+//! <C as h3::quic::OpenStreams<bytes::Bytes>>::BidiStream: Send + 'static,
+//! <<C as h3::quic::OpenStreams<bytes::Bytes>>::BidiStream as h3::quic::RecvStream>::Buf: Send + 'static
 //! {
 //!     let mut server_builder = h3::server::builder();
 //!     // Build the Connection

--- a/h3/src/tests/connection.rs
+++ b/h3/src/tests/connection.rs
@@ -966,10 +966,11 @@ where
     request_stream.recv_response().await
 }
 
-async fn response<S, B>(mut stream: server::RequestStream<S, B>)
+async fn response<S, B, R>(mut stream: server::RequestStream<S, B, R>)
 where
-    S: quic::RecvStream + SendStream<B>,
+    S: quic::RecvStream<Buf = R> + SendStream<B>,
     B: Buf,
+    R: Buf,
 {
     stream
         .send_response(

--- a/h3/src/tests/mod.rs
+++ b/h3/src/tests/mod.rs
@@ -39,7 +39,10 @@ pub fn init_tracing() {
 /// Only use this for testing purposes.
 async fn get_stream_blocking<C: quic::Connection<B>, B: Buf>(
     incoming: &mut crate::server::Connection<C, B>,
-) -> Option<(Request<()>, crate::server::RequestStream<C::BidiStream, B>)> {
+) -> Option<(
+    Request<()>,
+    crate::server::RequestStream<C::BidiStream, B, <C::BidiStream as quic::RecvStream>::Buf>,
+)> {
     let request_resolver = incoming.accept().await.ok()??;
     let (request, stream) = request_resolver.resolve_request().await.ok()?;
     Some((request, stream))


### PR DESCRIPTION
This is an attempt to address https://github.com/hyperium/h3/issues/308 and potentially handle vectored reads more efficiently (such as those supported by [s2n-quic](https://docs.rs/s2n-quic/latest/s2n_quic/stream/struct.ReceiveStream.html#method.poll_receive_vectored)).

This is certainly not ready for merging, but would be great to get some initial feedback.

Key changes are:
- `BufRecvStream` now holds `Option<R>` (where `R` is normally `Buf` from `RecvStream`) instead of `BufList`, `FrameStream` has its own `BufList` to deal with frames spanning multiple buffers
- `poll_data` from `FrameStream` returns separate set of `Bytes` for each chunk to deal more efficiently with vectored reads from backend