### PR TITLE
Model QUIC ConnectionClosed separately from ApplicationClose

### DIFF
--- a/h3-quinn/src/datagram.rs
+++ b/h3-quinn/src/datagram.rs
@@ -92,6 +92,9 @@ fn convert_h3_error_to_datagram_error(
         ConnectionErrorIncoming::ApplicationClose { error_code } => {
             h3_datagram::ConnectionErrorIncoming::ApplicationClose { error_code }
         }
+        ConnectionErrorIncoming::ConnectionClosed { error_code } => {
+            h3_datagram::ConnectionErrorIncoming::ConnectionClosed { error_code }
+        }
         ConnectionErrorIncoming::Timeout => h3_datagram::ConnectionErrorIncoming::Timeout,
         ConnectionErrorIncoming::InternalError(err) => {
             h3_datagram::ConnectionErrorIncoming::InternalError(err)

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -112,16 +112,41 @@ fn convert_connection_error(e: quinn::ConnectionError) -> h3::quic::ConnectionEr
                 error_code: application_close.error_code.into(),
             }
         }
+        quinn::ConnectionError::ConnectionClosed(connection_close) => {
+            ConnectionErrorIncoming::ConnectionClosed {
+                error_code: connection_close.error_code.into(),
+            }
+        }
         quinn::ConnectionError::TimedOut => ConnectionErrorIncoming::Timeout,
 
         error @ quinn::ConnectionError::VersionMismatch
         | error @ quinn::ConnectionError::Reset
         | error @ quinn::ConnectionError::LocallyClosed
         | error @ quinn::ConnectionError::CidsExhausted
-        | error @ quinn::ConnectionError::TransportError(_)
-        | error @ quinn::ConnectionError::ConnectionClosed(_) => {
+        | error @ quinn::ConnectionError::TransportError(_) => {
             ConnectionErrorIncoming::Undefined(Arc::new(error))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::convert_connection_error;
+    use h3::quic::ConnectionErrorIncoming;
+    use quinn::{ConnectionClose, ConnectionError, TransportErrorCode};
+
+    #[test]
+    fn connection_closed_is_mapped_to_structured_variant() {
+        let error = ConnectionError::ConnectionClosed(ConnectionClose {
+            error_code: TransportErrorCode::NO_ERROR,
+            frame_type: None,
+            reason: Default::default(),
+        });
+
+        assert!(matches!(
+            convert_connection_error(error),
+            ConnectionErrorIncoming::ConnectionClosed { error_code: 0 }
+        ));
     }
 }
 

--- a/h3/src/error/error.rs
+++ b/h3/src/error/error.rs
@@ -1,5 +1,5 @@
 //! This is the public facing error types for the h3 crate
-use crate::quic::ConnectionErrorIncoming;
+use crate::quic::{ConnectionErrorIncoming, QUIC_NO_ERROR};
 
 use super::{codes::Code, internal_error::InternalConnectionError};
 
@@ -48,6 +48,11 @@ impl ConnectionError {
             } => true,
             ConnectionError::Remote(ConnectionErrorIncoming::ApplicationClose { error_code })
                 if *error_code == Code::H3_NO_ERROR.value() =>
+            {
+                true
+            }
+            ConnectionError::Remote(ConnectionErrorIncoming::ConnectionClosed { error_code })
+                if *error_code == QUIC_NO_ERROR =>
             {
                 true
             }

--- a/h3/src/quic.rs
+++ b/h3/src/quic.rs
@@ -13,6 +13,9 @@ use crate::error::Code;
 pub use crate::proto::stream::{InvalidStreamId, StreamId};
 pub use crate::stream::WriteBuf;
 
+/// QUIC transport close code indicating graceful shutdown.
+pub const QUIC_NO_ERROR: u64 = 0;
+
 /// Error type to communicate that the quic connection was closed
 ///
 /// This is used by to implement the quic abstraction traits
@@ -21,6 +24,11 @@ pub enum ConnectionErrorIncoming {
     /// Error from the http3 layer
     ApplicationClose {
         /// http3 error code
+        error_code: u64,
+    },
+    /// QUIC connection was closed by peer
+    ConnectionClosed {
+        /// QUIC transport error code
         error_code: u64,
     },
     /// Quic connection timeout
@@ -41,6 +49,9 @@ impl Debug for ConnectionErrorIncoming {
             Self::ApplicationClose { error_code } => {
                 let error_code = Code::from(*error_code);
                 write!(f, "ApplicationClose({})", error_code)
+            }
+            Self::ConnectionClosed { error_code } => {
+                write!(f, "ConnectionClosed({:#x})", error_code)
             }
             Self::Timeout => write!(f, "Timeout"),
             Self::InternalError(arg0) => f.debug_tuple("InternalError").field(arg0).finish(),
@@ -99,6 +110,9 @@ impl Display for ConnectionErrorIncoming {
             ConnectionErrorIncoming::ApplicationClose { error_code } => {
                 let error_code = Code::from(*error_code);
                 write!(f, "ApplicationClose: {}", error_code)
+            }
+            ConnectionErrorIncoming::ConnectionClosed { error_code } => {
+                write!(f, "ConnectionClosed: {:#x}", error_code)
             }
             ConnectionErrorIncoming::Timeout => write!(f, "Timeout"),
             ConnectionErrorIncoming::InternalError(error) => {


### PR DESCRIPTION
## Summary

QUIC transport-level connection closures are currently mapped to `ConnectionErrorIncoming::Undefined`, which erases type information and makes downstream handling rely on debug strings or heuristics.

This change adds a dedicated `ConnectionClosed { error_code }` variant to `ConnectionErrorIncoming` and maps QUIC `ConnectionClosed` errors explicitly instead of treating them as undefined.

QUIC ConnectionClosed(NO_ERROR) represents graceful shutdown and should not be treated as an undefined error.

## What changed

- add `ConnectionErrorIncoming::ConnectionClosed { error_code }`
- map `quinn::ConnectionError::ConnectionClosed(...)` explicitly in `h3-quinn`
- keep `ApplicationClose` strictly HTTP/3-level
- keep `Undefined` as the fallback for errors that still do not have a structured mapping
- treat QUIC `NO_ERROR` as graceful shutdown in `ConnectionError::is_h3_no_error()`
- pass the new variant through the datagram adapter as well

## Why

`ApplicationClose` and QUIC `ConnectionClosed` carry different semantics and belong to different protocol layers.

`ApplicationClose` is an HTTP/3 application close.
`ConnectionClosed` is a QUIC transport close.

This PR keeps those separate instead of collapsing transport shutdown into `Undefined`.

This is also the connection-level equivalent of the fix in #315 for `StreamError::is_h3_no_error()`, which already handles the stream-level case via `RemoteTerminate`.

## Compatibility

This is a public enum API change: `ConnectionErrorIncoming` gains a new `ConnectionClosed` variant.

That is not strictly backwards-compatible for exhaustive matches, but it avoids erasing structured QUIC transport shutdowns behind `Undefined`, and matches the maintainer guidance that this crate can tolerate such updates in practice.

Unlike an open-ended `Other(...)`-style enum, this does not silently remap behavior at runtime; downstream exhaustive matches get a compile-time signal to handle the new transport-level case explicitly.

## Verification

- `cargo test -p h3-quinn connection_closed_is_mapped_to_structured_variant`
- `cargo check -p h3 -p h3-quinn -p h3-datagram`

Refs #325.
