### PR TITLE
frame: drain buffered bytes before propagating QUIC connection error

### DIFF
--- a/h3/src/frame.rs
+++ b/h3/src/frame.rs
@@ -70,7 +70,17 @@ where
         );
 
         loop {
-            let end = self.try_recv(cx)?;
+            // Hoist the QUIC error out of `?` so that any bytes pulled
+            // into `self.stream.buf_mut()` on prior wakes get one last
+            // chance through the decoder. Without this hoist, a
+            // CONNECTION_CLOSE frame coalesced with stream data in the
+            // same recv batch wins the race and discards a fully-
+            // decodable HEADERS frame.
+            let (end, pending_quic_err) = match self.try_recv(cx) {
+                Poll::Ready(Ok(end)) => (Poll::Ready(end), None),
+                Poll::Pending => (Poll::Pending, None),
+                Poll::Ready(Err(e)) => (Poll::Ready(true), Some(e)),
+            };
 
             return match self.decoder.decode(self.stream.buf_mut())? {
                 Some(Frame::Data(PayloadLen(len))) => {
@@ -82,11 +92,17 @@ where
                     Poll::Ready(Ok(frame))
                 }
                 Some(frame) => Poll::Ready(Ok(Some(frame))),
-                None => match end {
+                None => match (end, pending_quic_err) {
+                    // Decoder couldn't make progress on buffered bytes
+                    // and the underlying QUIC stream errored: surface
+                    // the cached error now. Fixed-point: this branch
+                    // terminates the loop because we consume the cached
+                    // error in the same iteration we observed it.
+                    (_, Some(err)) => Poll::Ready(Err(err)),
                     // Received a chunk but frame is incomplete, poll until we get `Pending`.
-                    Poll::Ready(false) => continue,
-                    Poll::Pending => Poll::Pending,
-                    Poll::Ready(true) => {
+                    (Poll::Ready(false), None) => continue,
+                    (Poll::Pending, None) => Poll::Pending,
+                    (Poll::Ready(true), None) => {
                         if self.stream.buf_mut().has_remaining() {
                             // Reached the end of receive stream, but there is still some data:
                             // The frame is incomplete.
@@ -112,23 +128,32 @@ where
             return Poll::Ready(Ok(None));
         };
 
-        let end = match self.try_recv(cx) {
-            Poll::Ready(Ok(end)) => end,
-            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-            Poll::Pending => false,
+        // Mirror the hoist from poll_next: a QUIC-level error must not
+        // discard already-buffered body bytes for the current frame.
+        let (end, pending_quic_err) = match self.try_recv(cx) {
+            Poll::Ready(Ok(end)) => (end, None),
+            Poll::Ready(Err(e)) => (true, Some(e)),
+            Poll::Pending => (false, None),
         };
         let data = self.stream.buf_mut().take_chunk(self.remaining_data);
 
-        match (data, end) {
-            (None, true) => Poll::Ready(Ok(None)),
-            (None, false) => Poll::Pending,
-            (Some(d), true)
-                if d.remaining() < self.remaining_data
+        match (data, end, pending_quic_err) {
+            // No more buffered body and QUIC errored: surface the error.
+            (None, _, Some(err)) => Poll::Ready(Err(err)),
+            (None, true, None) => Poll::Ready(Ok(None)),
+            (None, false, None) => Poll::Pending,
+            // Partial body for the current frame and the underlying
+            // stream / connection ended: caller MUST treat this as
+            // truncation. Same shape as the existing `Poll::Ready(true)`
+            // branch below — extended to also cover the QUIC error case.
+            (Some(d), end_or_err, pending)
+                if (end_or_err || pending.is_some())
+                    && d.remaining() < self.remaining_data
                     && !self.stream.buf_mut().has_remaining() =>
             {
                 Poll::Ready(Err(FrameStreamError::UnexpectedEnd))
             }
-            (Some(d), _) => {
+            (Some(d), _, _) => {
                 self.remaining_data -= d.remaining();
                 Poll::Ready(Ok(Some(d)))
             }
@@ -323,6 +348,7 @@ mod tests {
     use std::collections::VecDeque;
 
     use crate::proto::{coding::Encode, frame::FrameType, varint::VarInt};
+    use crate::quic::ConnectionErrorIncoming;
 
     // Decoder
 
@@ -434,6 +460,65 @@ mod tests {
             Ok(Some(b)) if b.remaining() == 4
         );
         assert_poll_matches!(|cx| stream.poll_next(cx), Ok(Some(Frame::Headers(_))));
+    }
+
+    /// Regression: a QUIC CONNECTION_CLOSE that lands in the same recv
+    /// batch as a fully-decodable HEADERS frame must NOT discard the
+    /// frame. Pre-fix, `try_recv`'s `?` propagated the connection error
+    /// before `decoder.decode` got to consume the bytes already in
+    /// `BufRecvStream::buf`. Post-fix, the decoder runs once on the
+    /// buffered bytes and produces the frame; the error surfaces on
+    /// the next poll only if no frame can be parsed.
+    #[tokio::test]
+    async fn poll_next_drains_buffered_headers_before_quic_close() {
+        let mut recv = FakeRecv::default();
+        let mut buf = BytesMut::with_capacity(64);
+        Frame::headers(&b"header"[..]).encode_with_payload(&mut buf);
+        // Headers chunk is fully buffered, then poll_data signals a
+        // connection-level error on the next poll — exactly the
+        // shape produced by an io_uring-coalesced datagram with
+        // STREAM(FIN) + CONNECTION_CLOSE(H3_NO_ERROR).
+        recv.chunk_then_error(
+            buf.freeze(),
+            StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code: 0x100 },
+            },
+        );
+        let mut stream: FrameStream<_, ()> = FrameStream::new(BufRecvStream::new(recv));
+
+        // First poll: drains buffered HEADERS frame instead of erroring.
+        assert_poll_matches!(|cx| stream.poll_next(cx), Ok(Some(Frame::Headers(_))));
+        // Second poll: nothing left to decode, error surfaces.
+        assert_poll_matches!(|cx| stream.poll_next(cx), Err(FrameStreamError::Quic(_)));
+    }
+
+    /// Regression: same shape as poll_next, but on the body path. A
+    /// connection error must not strand DATA frame body bytes that
+    /// were buffered before the error arrived.
+    #[tokio::test]
+    async fn poll_data_drains_buffered_body_before_quic_close() {
+        let mut recv = FakeRecv::default();
+        let mut buf = BytesMut::with_capacity(64);
+        Frame::Data(Bytes::from("body")).encode_with_payload(&mut buf);
+        recv.chunk_then_error(
+            buf.freeze(),
+            StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code: 0x100 },
+            },
+        );
+        let mut stream: FrameStream<_, ()> = FrameStream::new(BufRecvStream::new(recv));
+
+        // First, poll_next gives us the DATA frame header.
+        assert_poll_matches!(
+            |cx| stream.poll_next(cx),
+            Ok(Some(Frame::Data(PayloadLen(4))))
+        );
+        // Then poll_data drains the body even though the underlying
+        // stream is now signaling a connection error.
+        assert_poll_matches!(
+            |cx| to_bytes(stream.poll_data(cx)),
+            Ok(Some(b)) if b.remaining() == 4
+        );
     }
 
     #[tokio::test]
@@ -595,11 +680,23 @@ mod tests {
     #[derive(Default)]
     struct FakeRecv {
         chunks: VecDeque<Bytes>,
+        pending_error: Option<StreamErrorIncoming>,
     }
 
     impl FakeRecv {
         fn chunk(&mut self, buf: Bytes) -> &mut Self {
             self.chunks.push_back(buf);
+            self
+        }
+
+        /// Queue a chunk to be returned on a subsequent poll, followed
+        /// by a synthetic connection-level error. Models the recv batch
+        /// where stream data and CONNECTION_CLOSE land in the same
+        /// underlying read — the race this regression covers.
+        #[allow(dead_code)]
+        fn chunk_then_error(&mut self, buf: Bytes, err: StreamErrorIncoming) -> &mut Self {
+            self.chunks.push_back(buf);
+            self.pending_error = Some(err);
             self
         }
     }
@@ -611,7 +708,13 @@ mod tests {
             &mut self,
             _: &mut Context<'_>,
         ) -> Poll<Result<Option<Self::Buf>, StreamErrorIncoming>> {
-            Poll::Ready(Ok(self.chunks.pop_front()))
+            if let Some(chunk) = self.chunks.pop_front() {
+                return Poll::Ready(Ok(Some(chunk)));
+            }
+            match self.pending_error.take() {
+                Some(err) => Poll::Ready(Err(err)),
+                None => Poll::Ready(Ok(None)),
+            }
         }
 
         fn stop_sending(&mut self, _: u64) {


### PR DESCRIPTION
# frame: drain buffered bytes before propagating QUIC connection error

Fixes #338.

## Problem

`FrameStream::try_recv` propagates a connection-level error from
`BufRecvStream::poll_read` via `?` before the frame decoder gets to run
against bytes that may already be sitting in `BufRecvStream::buf` from
a previous wake. When a QUIC stack delivers stream data and a
`CONNECTION_CLOSE` (or other connection error) in the same recv batch —
common on Linux with io_uring's batched recvmsg and coalesced UDP
datagrams — buffered HEADERS / DATA bytes are discarded and clients
see `StreamError::ConnectionError` instead of the response that was
already on the wire.

The QUIC layer is innocent here: quinn-proto's per-stream assembler is
not flushed by `close_common`, and `Chunks::next()` returns buffered
chunks before checking connection state. The discard is purely at
h3's frame layer.

`H3_NO_ERROR` is RFC 9114 §8.1's "graceful shutdown without an error"
code. Today, a backend that uses it correctly (per-connection request
limits, drain/rolling deploy, stateless backends) produces 502s at the
client.

## Fix

Hoist the QUIC error out of `try_recv`'s `?` path. When `poll_read`
returns an error, cache it for the current iteration; let
`decoder.decode(self.stream.buf_mut())` run once against whatever is
already buffered. If the decoder produces a frame, surface it normally.
If `decoder.decode` returns `None`, surface the cached error.

Same shape applied to `FrameStream::poll_data` so DATA frame body
bytes that were buffered before the error are not stranded.

### Termination

Each iteration consumes its own cached error in the same iteration it
was observed. A partial-frame buffer that the decoder cannot resolve
exits the loop with the cached error in the `None` arm of the match —
no opportunity for an infinite loop.

### Forward progress

When the decoder DOES produce a frame on the cached-error iteration,
the next poll re-issues `poll_read`, which returns the same error.
The buffered bytes have shrunk by the consumed frame's length, so
iterations are bounded by the buffer size.

## Tests

Two new tests in `frame.rs::tests`:

- `poll_next_drains_buffered_headers_before_quic_close` — synthesizes a
  HEADERS frame followed by an `ApplicationClose { error_code: 0x100 }`
  via `FakeRecv::chunk_then_error`. First poll yields the frame, second
  poll surfaces the error.
- `poll_data_drains_buffered_body_before_quic_close` — same shape on
  the body path. `poll_next` yields the DATA frame header, `poll_data`
  drains the buffered 4-byte body even though the next poll would
  return the connection error.

`FakeRecv` is extended with a `chunk_then_error` helper that queues a
synthetic `StreamErrorIncoming::ConnectionErrorIncoming` for the next
poll after a chunk drains. This is the smallest model of the recv-batch
race that a unit test can construct without a live QUIC backend.

The existing tests in `frame.rs` still pass (the change is a no-op for
the non-error path).

## Compatibility

- Public API: unchanged. `poll_next` and `poll_data` keep the same
  signatures and the same return-shape contract — successful frames
  continue to win, errors continue to surface, the only difference is
  the ordering when both are pending.
- Internal API: no callers outside `frame.rs` are affected.
- Behavioral compat: a backend that intentionally aborts a stream with
  a non-`NO_ERROR` code mid-frame will now have its buffered partial
  data delivered before the error fires. This is arguably more correct
  (the bytes WERE received before the abort) but worth flagging in case
  any downstream depends on the prior "discard on error" semantic.

## Downstream context

This is the root-cause fix for the recv_response analog of [#NNN
(predecessor PR for recv_data graceful close)]. The recv_data path was
worked around at the application layer in commit `dbc9e09` via a
`drain_h3_response_body` helper that re-implemented buffer-aware
recovery one level up. With this PR, that helper can be simplified —
the underlying decoder will already drain on its own — but I've kept
the helper unmodified to keep the change here minimal. Happy to follow
up with simplification once this lands if maintainers prefer.

The recv_response path is the one this PR specifically fixes: at that
boundary the application has no buffered bytes of its own to fall back
on, so the only fix is at h3's frame layer.

## Refs

- RFC 9114 §8.1 — H3 error codes
- Issue #338 — bug report with reproducer and rationale
- Downstream consumer: [ferrum-edge#506](https://github.com/ferrum-edge/ferrum-edge/pull/506) — gateway-side suppression of capability-downgrade for graceful closes (treats the symptom while we await this upstream fix)
