### PR TITLE
Update documentation of `recv_data()`/`poll_recv_data()`

### DIFF
--- a/h3/src/client/stream.rs
+++ b/h3/src/client/stream.rs
@@ -184,14 +184,18 @@ where
         Ok(resp)
     }
 
-    /// Receive some of the request body.
+    /// Receive some of the response body.
+    ///
+    /// This returns a chunk of the response body, or `None` if the response body is finished.
     // TODO what if called before recv_response ?
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     pub async fn recv_data(&mut self) -> Result<Option<impl Buf>, StreamError> {
         future::poll_fn(|cx| self.poll_recv_data(cx)).await
     }
 
-    /// Receive request body
+    /// Receive some of the response body.
+    ///
+    /// This returns a chunk of the response body, or `None` if the response body is finished.
     pub fn poll_recv_data(
         &mut self,
         cx: &mut Context<'_>,

--- a/h3/src/connection.rs
+++ b/h3/src/connection.rs
@@ -845,7 +845,7 @@ impl<S, B> RequestStream<S, B>
 where
     S: quic::RecvStream,
 {
-    /// Receive some of the request body.
+    /// Receive some of the request/response body.
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     pub fn poll_recv_data(
         &mut self,

--- a/h3/src/server/stream.rs
+++ b/h3/src/server/stream.rs
@@ -65,13 +65,17 @@ where
     S: quic::RecvStream,
     B: Buf,
 {
-    /// Receive data sent from the client
+    /// Receive data sent from the client.
+    ///
+    /// This returns a chunk of the request body, or `None` if the request body is finished.
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     pub async fn recv_data(&mut self) -> Result<Option<impl Buf>, StreamError> {
         future::poll_fn(|cx| self.poll_recv_data(cx)).await
     }
 
-    /// Poll for data sent from the client
+    /// Poll for data sent from the client.
+    ///
+    /// This returns a chunk of the request body, or `None` if the request body is finished.
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     pub fn poll_recv_data(
         &mut self,


### PR DESCRIPTION
This updates the documentation of various `recv_data()` and `poll_recv_data()` methods. My primary confusion was that they only return a frame of the body at a time, so I made mention of that in the methods that didn't make it explicit yet. There were also some incorrect references to requests and responses, so I cleaned those up.