### PR TITLE
Apply backpressure before reading more frames

### DIFF
--- a/h3/src/frame.rs
+++ b/h3/src/frame.rs
@@ -70,33 +70,33 @@ where
         );
 
         loop {
-            let end = self.try_recv(cx)?;
-
-            return match self.decoder.decode(self.stream.buf_mut())? {
+            match self.decoder.decode(self.stream.buf_mut())? {
                 Some(Frame::Data(PayloadLen(len))) => {
                     self.remaining_data = len;
-                    Poll::Ready(Ok(Some(Frame::Data(PayloadLen(len)))))
+                    return Poll::Ready(Ok(Some(Frame::Data(PayloadLen(len)))));
                 }
                 frame @ Some(Frame::WebTransportStream(_)) => {
                     self.remaining_data = usize::MAX;
-                    Poll::Ready(Ok(frame))
+                    return Poll::Ready(Ok(frame));
                 }
-                Some(frame) => Poll::Ready(Ok(Some(frame))),
-                None => match end {
-                    // Received a chunk but frame is incomplete, poll until we get `Pending`.
-                    Poll::Ready(false) => continue,
-                    Poll::Pending => Poll::Pending,
-                    Poll::Ready(true) => {
-                        if self.stream.buf_mut().has_remaining() {
-                            // Reached the end of receive stream, but there is still some data:
-                            // The frame is incomplete.
-                            Poll::Ready(Err(FrameStreamError::UnexpectedEnd))
-                        } else {
-                            Poll::Ready(Ok(None))
-                        }
+                Some(frame) => return Poll::Ready(Ok(Some(frame))),
+                None => {}
+            }
+
+            match self.try_recv(cx)? {
+                // Received a chunk but the frame is incomplete, poll until we get `Pending`.
+                Poll::Ready(false) => continue,
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(true) => {
+                    if self.stream.buf_mut().has_remaining() {
+                        // Reached the end of receive stream, but there is still some data:
+                        // The frame is incomplete.
+                        return Poll::Ready(Err(FrameStreamError::UnexpectedEnd));
+                    } else {
+                        return Poll::Ready(Ok(None));
                     }
-                },
-            };
+                }
+            }
         }
     }
 
@@ -320,7 +320,7 @@ mod tests {
     use assert_matches::assert_matches;
     use bytes::{BufMut, Bytes, BytesMut};
     use futures_util::future::poll_fn;
-    use std::collections::VecDeque;
+    use std::{cell::Cell, collections::VecDeque, rc::Rc};
 
     use crate::proto::{coding::Encode, frame::FrameType, varint::VarInt};
 
@@ -434,6 +434,46 @@ mod tests {
             Ok(Some(b)) if b.remaining() == 4
         );
         assert_poll_matches!(|cx| stream.poll_next(cx), Ok(Some(Frame::Headers(_))));
+    }
+
+    #[tokio::test]
+    async fn poll_next_applies_backpressure_before_reading_more_chunks() {
+        const CHUNK_COUNT: usize = 64;
+        const FRAMES_PER_CHUNK: usize = 16;
+        const FRAME_PAYLOAD_SIZE: usize = 1024;
+
+        let mut encoded_chunk = BytesMut::new();
+        let payload = Bytes::from(vec![0_u8; FRAME_PAYLOAD_SIZE]);
+        for _ in 0..FRAMES_PER_CHUNK {
+            Frame::headers(payload.clone()).encode_with_payload(&mut encoded_chunk);
+        }
+        let encoded_chunk = encoded_chunk.freeze();
+        let max_buffered = encoded_chunk.len();
+
+        let mut recv = FakeRecv::default();
+        for _ in 0..CHUNK_COUNT {
+            recv.chunk(encoded_chunk.clone());
+        }
+        let transport_polls = recv.poll_count.clone();
+
+        let mut stream: FrameStream<_, ()> = FrameStream::new(BufRecvStream::new(recv));
+
+        // Model a consumer that processes one frame per wake while the
+        // transport can provide chunks containing many complete frames.
+        for _ in 0..CHUNK_COUNT {
+            assert_poll_matches!(|cx| stream.poll_next(cx), Ok(Some(Frame::Headers(_))));
+        }
+
+        let buffered = stream.stream.buf().remaining();
+        assert!(
+            buffered <= max_buffered,
+            "frame buffering grew past one transport chunk: {buffered} > {max_buffered}"
+        );
+        assert_eq!(
+            transport_polls.get(),
+            CHUNK_COUNT.div_ceil(FRAMES_PER_CHUNK),
+            "transport was polled while complete frames were still buffered"
+        );
     }
 
     #[tokio::test]
@@ -595,6 +635,7 @@ mod tests {
     #[derive(Default)]
     struct FakeRecv {
         chunks: VecDeque<Bytes>,
+        poll_count: Rc<Cell<usize>>,
     }
 
     impl FakeRecv {
@@ -611,6 +652,7 @@ mod tests {
             &mut self,
             _: &mut Context<'_>,
         ) -> Poll<Result<Option<Self::Buf>, StreamErrorIncoming>> {
+            self.poll_count.set(self.poll_count.get() + 1);
             Poll::Ready(Ok(self.chunks.pop_front()))
         }
 


### PR DESCRIPTION
## Summary

Decode complete frames already present in `FrameStream`'s receive buffer before polling the underlying QUIC transport for another chunk.

This prevents a slow frame consumer from causing `BufRecvStream` to accumulate a new transport chunk on every wake while complete frames are still buffered.

## Root cause

`FrameStream::poll_next` called `try_recv` before attempting to decode the existing buffer. If one transport chunk contained multiple HTTP/3 frames, every subsequent frame poll could read and append another chunk before consuming the frames already available.

## Regression test

The new deterministic test models 64 immediately available transport chunks, each containing 16 HEADERS frames with a 1,024-byte payload, while the consumer processes one frame per wake.

On current `master`, the test observed:

- 64 underlying transport polls
- 985,920 bytes left buffered after consuming 64 frames
- one encoded transport chunk is 16,432 bytes

With this change:

- only 4 transport polls are needed for the same 64 frames
- buffering remains bounded to the currently consumed transport chunk

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p h3 -p h3-quinn`
- 228 unit tests passed
- 9 documentation tests passed

## Prior and related work

After opening this draft, I noticed the issue timeline links to [0x676e67/http3#2](https://github.com/0x676e67/http3/pull/2). That June 2026 fork patch already contains the equivalent `FrameStream` reordering and a smaller two-frame regression test, alongside unrelated QPACK changes. Credit to @0x676e67 for that earlier implementation.

This draft was developed independently against current upstream `master`; its additional contribution is the stronger multi-chunk regression scenario and measured baseline above. Maintainers may prefer to adapt the earlier commit or this focused patch, and I am happy to adjust attribution or approach accordingly.

The same regression scenario also passes on the broader receive-buffer refactor in #328. This draft offers a smaller near-term change while that larger design is evaluated.

Fixes #308